### PR TITLE
Switched from l3regex to expl3 package requirement

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -191,7 +191,7 @@
 % compatibility package with older versions of moderncv
 \RequirePackageWithOptions{moderncvcompatibility}
 
-\RequirePackage{l3regex}
+\RequirePackage{expl3}
 
 %-------------------------------------------------------------------------------
 %                class definition


### PR DESCRIPTION
Taken from https://github.com/xdanaux/moderncv/pull/60.