### PR TITLE
Add stackoverflow to \social command

### DIFF
--- a/examples/template.tex
+++ b/examples/template.tex
@@ -32,6 +32,7 @@
 \phone[fax]{+3~(456)~789~012}
 \email{john@doe.org}                               % optional, remove / comment the line if not wanted
 \homepage{www.johndoe.com}                         % optional, remove / comment the line if not wanted
+\social[stackoverflow]{0000000/johndoe}            % optional, remove / comment the line if not wanted
 \social[linkedin]{john.doe}                        % optional, remove / comment the line if not wanted
 \social[xing]{john\_doe}                           % optional, remove / comment the line if not wanted
 \social[twitter]{jdoe}                             % optional, remove / comment the line if not wanted
@@ -167,3 +168,4 @@ Albert Einstein discovered that $e=mc^2$ in 1905.
 
 
 %% end of file `template.tex'.
+

--- a/moderncv.cls
+++ b/moderncv.cls
@@ -255,21 +255,26 @@
     }
 
 
+% http://latex.org/forum/viewtopic.php?t=12239
+\def\SplitMyMacro#1/#2{#2}
+    
+    
 % adds a social link to one's personal information (optional)
 % usage: \social[<optional type>][<optional url>]{<account name>}
 % where <optional type> should be either "linkedin", "xing", "twitter", "github", "gitlab" or "skype"
 \collectionnew{socials}
 \NewDocumentCommand{\social}{O{}O{}m}{%
   \ifthenelse{\equal{#2}{}}%
-    {%
-      \ifthenelse{\equal{#1}{linkedin}}{\collectionadd[linkedin]{socials}{\protect\httplink[#3]{www.linkedin.com/in/#3}}} {}%
-      \ifthenelse{\equal{#1}{xing}}    {\collectionadd[xing]{socials}    {\protect\httplink[#3]{www.xing.com/profile/#3}}}{}%
-      \ifthenelse{\equal{#1}{twitter}} {\collectionadd[twitter]{socials} {\protect\httplink[#3]{www.twitter.com/#3}}}     {}%
-      \ifthenelse{\equal{#1}{github}}  {\collectionadd[github]{socials}  {\protect\httplink[#3]{www.github.com/#3}}}      {}%
-      \ifthenelse{\equal{#1}{gitlab}}  {\collectionadd[gitlab]{socials}  {\protect\httplink[#3]{www.gitlab.com/#3}}}      {}%
+  {%
+    \ifthenelse{\equal{#1}{linkedin}}{\collectionadd[linkedin]{socials}{\protect\httpslink[#3]{www.linkedin.com/in/#3}}} {}%
+      \ifthenelse{\equal{#1}{xing}}    {\collectionadd[xing]{socials}    {\protect\httpslink[#3]{www.xing.com/profile/#3}}}{}%
+      \ifthenelse{\equal{#1}{twitter}} {\collectionadd[twitter]{socials} {\protect\httpslink[#3]{www.twitter.com/#3}}}     {}%
+      \ifthenelse{\equal{#1}{github}}  {\collectionadd[github]{socials}  {\protect\httpslink[#3]{www.github.com/#3}}}      {}%
+      \ifthenelse{\equal{#1}{gitlab}}  {\collectionadd[gitlab]{socials}  {\protect\httpslink[#3]{www.gitlab.com/#3}}}      {}%
+      \ifthenelse{\equal{#1}{stackoverflow}}  {\collectionadd[stackoverflow]{socials}  {\protect\httpslink[\SplitMyMacro#3]{stackoverflow.com/users/#3}}}      {}%
       \ifthenelse{\equal{#1}{skype}}   {\collectionadd[skype]{socials}   {#3}}                                            {}%
     }
-    {\collectionadd[#1]{socials}{\protect\httplink[#3]{#2}}}}
+    {\collectionadd[#1]{socials}{\protect\httpslink[#3]{#2}}}}
 
 % defines additional personal information (optional)
 % usage: \extrainfo{<text>}
@@ -310,6 +315,7 @@
 \newcommand*{\githubsocialsymbol}  {}
 \newcommand*{\gitlabsocialsymbol}  {}
 \newcommand*{\skypesocialsymbol}   {}
+\newcommand*{\stackoverflowsocialsymbol} {}
 
 % other
 %------
@@ -507,6 +513,13 @@
     {\href{http://#2}{#2}}%
     {\href{http://#2}{#1}}}
 
+% makes an https hyperlink
+% usage: \httpslink[optional text]{link}
+\newcommand*{\httpslink}[2][]{%
+  \ifthenelse{\equal{#1}{}}%
+    {\href{https://#2}{#2}}%
+    {\href{https://#2}{#1}}}
+  
 % makes an email hyperlink
 % usage: \emaillink[optional text]{link}
 \newcommand*{\emaillink}[2][]{%

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -39,6 +39,7 @@
 \renewcommand*{\githubsocialsymbol}  {{\small\faGithub}~}             % alternative: \faGithubSquare, \faGithubSquare
 \renewcommand*{\gitlabsocialsymbol}  {{\small\faGitlab}~}
 \renewcommand*{\skypesocialsymbol}   {{\small\faSkype}~}
+\renewcommand*{\stackoverflowsocialsymbol} {{\small\faStackOverflow}~}
 
 
 \endinput

--- a/moderncviconsletters.sty
+++ b/moderncviconsletters.sty
@@ -46,6 +46,7 @@
 \renewcommand*{\githubsocialsymbol}  {\textbf{gh}~}
 \renewcommand*{\gitlabsocialsymbol}  {\textbf{gl}~}
 \renewcommand*{\skypesocialsymbol}   {\textbf{sk}~}
+\renewcommand*{\stackoverflowsymbol} {\textbf{so}~}
 
 \renewcommand*{\listitemsymbol}      {\labelitemi~}
 

--- a/moderncviconsmarvosym.sty
+++ b/moderncviconsmarvosym.sty
@@ -224,6 +224,7 @@
     \protect\end{tikzpicture}}%
   ~}
 \renewcommand*{\gitlabsocialsymbol}{}
+\renewcommand*{\stackoverflowsymbol}{}
 \renewcommand*{\skypesocialsymbol}  {%
   \protect\raisebox{-0.15em}{%
     \protect\begin{tikzpicture}[y=0.08em, x=0.08em, xscale=0.020, yscale=-0.020, inner sep=0pt, outer sep=0pt]


### PR DESCRIPTION
Same pull request as on https://github.com/xdanaux/moderncv.

Adds the stackoverlow website as an option to the `\social` command. 