### PR TITLE
added bitbucket option to \social

### DIFF
--- a/examples/template-multibib.tex
+++ b/examples/template-multibib.tex
@@ -37,6 +37,7 @@
 \social[twitter]{jdoe}                             % optional, remove / comment the line if not wanted
 \social[github]{jdoe}                              % optional, remove / comment the line if not wanted
 \social[gitlab]{jdoe}                              % optional, remove / comment the line if not wanted
+\social[bitbucket]{jdoe}                           % optional, remove / comment the line if not wanted
 \social[skype]{jdoe}                               % optional, remove / comment the line if not wanted
 \extrainfo{additional information}                 % optional, remove / comment the line if not wanted
 \photo[64pt][0.4pt]{picture}                       % optional, remove / comment the line if not wanted; '64pt' is the height the picture must be resized to, 0.4pt is the thickness of the frame around it (put it to 0pt for no frame) and 'picture' is the name of the picture file

--- a/examples/template.tex
+++ b/examples/template.tex
@@ -38,6 +38,7 @@
 \social[github]{jdoe}                              % optional, remove / comment the line if not wanted
 \social[gitlab]{jdoe}                              % optional, remove / comment the line if not wanted
 \social[stackoverflow]{0000000/johndoe}            % optional, remove / comment the line if not wanted
+\social[bitbucket]{jdoe}                           % optional, remove / comment the line if not wanted
 \social[skype]{jdoe}                               % optional, remove / comment the line if not wanted
 \social[orcid]{0000-0000-000-000}                  % optional, remove / comment the line if not wanted
 \social[researchgate]{jdoe}                        % optional, remove / comment the line if not wanted

--- a/moderncv.cls
+++ b/moderncv.cls
@@ -261,7 +261,7 @@
     
 % adds a social link to one's personal information (optional)
 % usage: \social[<optional type>][<optional url>]{<account name>}
-% where <optional type> should be either "linkedin", "xing", "twitter", "github", "gitlab" or "skype"
+% where <optional type> should be either "linkedin", "xing", "twitter", "github", "gitlab", "bitbucket" or "skype"
 \collectionnew{socials}
 \NewDocumentCommand{\social}{O{}O{}m}{%
   \ifthenelse{\equal{#2}{}}%
@@ -272,6 +272,7 @@
       \ifthenelse{\equal{#1}{github}}       {\collectionadd[github]{socials}       {\protect\httpslink[#3]{www.github.com/#3}}}              {}%
       \ifthenelse{\equal{#1}{gitlab}}       {\collectionadd[gitlab]{socials}       {\protect\httpslink[#3]{www.gitlab.com/#3}}}              {}%
       \ifthenelse{\equal{#1}{stackoverflow}}{\collectionadd[stackoverflow]{socials}{\protect\httpslink[#3]{stackoverflow.com/users/#3}}}     {}%
+      \ifthenelse{\equal{#1}{bitbucket}}    {\collectionadd[bitbucket]{socials}{\protect\httplink[#3]{www.bitbucket.org/#3}}}   {}%
       \ifthenelse{\equal{#1}{skype}}        {\collectionadd[skype]{socials}        {#3}}                                                     {}%
       \ifthenelse{\equal{#1}{orcid}}        {\collectionadd[orcid]{socials}        {\protect\httpslink[#3]{orcid.org/#3}}}                   {}%
       \ifthenelse{\equal{#1}{researchgate}} {\collectionadd[researchgate]{socials} {\protect\httpslink[#3]{www.researchgate.net/profile/#3}}}{}%
@@ -318,6 +319,7 @@
 \newcommand*{\githubsocialsymbol}       {}
 \newcommand*{\gitlabsocialsymbol}       {}
 \newcommand*{\stackoverflowsocialsymbol}{}
+\newcommand*{\bitbucketsocialsymbol}    {}
 \newcommand*{\skypesocialsymbol}        {}
 \newcommand*{\orcidsocialsymbol}        {}
 \newcommand*{\researchgatesocialsymbol} {}

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -41,6 +41,7 @@
 \renewcommand*{\githubsocialsymbol}       {{\small\faGithub}~}             % alternative: \faGithubSquare, \faGithubSquare
 \renewcommand*{\gitlabsocialsymbol}       {{\small\faGitlab}~}
 \renewcommand*{\stackoverflowsocialsymbol}{{\small\faStackOverflow}~}
+\renewcommand*{\bitbucketsocialsymbol}    {{\small\faBitbucket}~}
 \renewcommand*{\skypesocialsymbol}        {{\small\faSkype}~}
 \renewcommand*{\orcidsocialsymbol}        {{\small\aiOrcid}~}
 \renewcommand*{\researchgatesocialsymbol} {{\small\aiResearchGate}~}

--- a/moderncviconsletters.sty
+++ b/moderncviconsletters.sty
@@ -46,6 +46,7 @@
 \renewcommand*{\githubsocialsymbol}       {\textbf{gh}~}
 \renewcommand*{\gitlabsocialsymbol}       {\textbf{gl}~}
 \renewcommand*{\stackoverflowsocialsymbol}{\textbf{so}~}
+\renewcommand*{\bitbucketsocialsymbol}    {\textbf{bb}~}
 \renewcommand*{\skypesocialsymbol}        {\textbf{sk}~}
 \renewcommand*{\orcidsocialsymbol}        {\textbf{orcid}~}
 \renewcommand*{\researchgatesocialsymbol} {\textbf{rg}~}

--- a/moderncviconsmarvosym.sty
+++ b/moderncviconsmarvosym.sty
@@ -228,6 +228,7 @@
 \renewcommand*{\orcidsocialsymbol}{}
 \renewcommand*{\researchgatesocialsymbol}{}
 \renewcommand*{\researchidsocialsymbol}{}
+\renewcommand*{\bitbucketsocialsymbol}{}
 \renewcommand*{\skypesocialsymbol}  {%
   \protect\raisebox{-0.15em}{%
     \protect\begin{tikzpicture}[y=0.08em, x=0.08em, xscale=0.020, yscale=-0.020, inner sep=0pt, outer sep=0pt]


### PR DESCRIPTION
This adds a `bitbucket` option to the `\social` command, just in line with the other supported VCS hosters.

Basically what I submitted to https://github.com/xdanaux/moderncv/pull/36.