### PR TITLE
Implement detokenize in links to fix use of underscores

### DIFF
--- a/KNOWN_BUGS
+++ b/KNOWN_BUGS
@@ -9,7 +9,7 @@
   when used with bibentry, through the output is actually correct. Amongst other,
   this causes compilation by LyX to stop.
 - The space after a cventry gets eaten up when the last argument contains a nested
-  itemize environment. An ugly hack and uncomplete solution was implemented by
+  itemize environment. An ugly hack and incomplete solution was implemented by
   including a \strut in every item label, but this doesn't solve the problem for
-  multi-line items. Ideally, the strut should end the item, but there seem to be
+  multi-line items. Ideally, the strut should end the item, but there seems to be
   no way to do this.

--- a/moderncv.cls
+++ b/moderncv.cls
@@ -517,14 +517,14 @@
 \newcommand*{\link}[2][]{%
   \ifthenelse{\equal{#1}{}}%
     {\href{#2}{#2}}%
-    {\href{#2}{#1}}}
+    {\href{#2}{\detokenize{#1}}}}
 
 % makes a http hyperlink
 % usage: \httplink[optional text]{link}
 \newcommand*{\httplink}[2][]{%
   \ifthenelse{\equal{#1}{}}%
     {\href{http://#2}{#2}}%
-    {\href{http://#2}{#1}}}
+    {\href{http://#2}{\detokenize{#1}}}}
 
 
 % makes an https hyperlink
@@ -532,15 +532,15 @@
 \newcommand*{\httpslink}[2][]{%
   \ifthenelse{\equal{#1}{}}%
     {\href{https://#2}{#2}}%
-    {\href{https://#2}{#1}}}
+    {\href{https://#2}{\detokenize{#1}}}}
 
 % makes an email hyperlink
 % usage: \emaillink[optional text]{link}
 \newcommand*{\emaillink}[2][]{%
   \ifthenelse{\equal{#1}{}}%
     {\href{mailto:#2}{#2}}%
-    {\href{mailto:#2}{#1}}}
     
+    {\href{mailto:#2}{\detokenize{#1}}}}
 % makes a tel hyperlink
 % usage: \tellink[optional text]{link}
 \newcommand*{\tellink}[2][]{%

--- a/moderncvstyleclassic.sty
+++ b/moderncvstyleclassic.sty
@@ -36,7 +36,7 @@
 %\fi
 
 % symbols
-\moderncvicons{marvosym}
+\moderncvicons{awesome}
 
 
 %-------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes issue #23 
Implement detokenize in links to fix use of underscores (and other characters) in social links; change icon package in classic style to same as casual since so many were missing. Also fixed a couple typos I found.