### PR TITLE
Restore pdflatex compatibility

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Install TeX Live
-        run: sudo apt install texlive-full
+        run: sudo apt update && sudo apt install texlive-full
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build pdf

--- a/moderncvstylebanking.sty
+++ b/moderncvstylebanking.sty
@@ -49,7 +49,12 @@
 %\fi
 
 % symbols
-\moderncvicons{awesome}
+\RequirePackage{ifxetex}
+\ifxetexorluatex
+  \moderncvicons{awesome}
+\else
+  \moderncvicons{marvosym}
+\fi
 
 
 %-------------------------------------------------------------------------------

--- a/moderncvstylecasual.sty
+++ b/moderncvstylecasual.sty
@@ -36,7 +36,12 @@
 %\fi
 
 % symbols
-\moderncvicons{awesome}
+\RequirePackage{ifxetex}
+\ifxetexorluatex
+  \moderncvicons{awesome}
+\else
+  \moderncvicons{marvosym}
+\fi
 
 
 %-------------------------------------------------------------------------------

--- a/moderncvstyleclassic.sty
+++ b/moderncvstyleclassic.sty
@@ -36,7 +36,12 @@
 %\fi
 
 % symbols
-\moderncvicons{awesome}
+\RequirePackage{ifxetex}
+\ifxetexorluatex
+  \moderncvicons{awesome}
+\else
+  \moderncvicons{marvosym}
+\fi
 
 
 %-------------------------------------------------------------------------------

--- a/moderncvstylefancy.sty
+++ b/moderncvstylefancy.sty
@@ -31,7 +31,12 @@
 %\fi
 
 % symbols
-\moderncvicons{awesome}
+\RequirePackage{ifxetex}
+\ifxetexorluatex
+  \moderncvicons{awesome}
+\else
+  \moderncvicons{marvosym}
+\fi
 
 
 %-------------------------------------------------------------------------------


### PR DESCRIPTION
Compiling currently fails with pdflatex with error `Encoding scheme "TU" unknown.` (see e.g. aside in [issue #23](https://github.com/moderncv/moderncv/issues/23#issuecomment-753077393) about compiling with xetex).
This is because the [academicons package](https://github.com/diogo-fernan/academicons), required for the "awesome" icons doesn't support pdflatex and doesn't seem very likely to.

This PR adds a compiler switch to the CV styles using the "awesome" icons to fallback to "marvosym" if compiling with neither Xe(La)TeX nor Lua(La)TeX (the compilers supported by academicons).

As for documenting/noting, etc., that is not addressed here, but either a print-out warning about falling back or adding comments / flags to the template file (or documentation) may be in order.