### PR TITLE
add WhatsApp, Signal, Matrix social, WhatsApp icon

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -291,6 +291,9 @@
       \ifthenelse{\equal{#1}{researchgate}} {\collectionadd[researchgate]{socials} {\protect\httpslink[#3]{www.researchgate.net/profile/#3}}}      {}%
       \ifthenelse{\equal{#1}{researcherid}} {\collectionadd[researcherid]{socials} {\protect\httpslink[#3]{www.researcherid.com/rid/#3}}}          {}%
       \ifthenelse{\equal{#1}{telegram}}     {\collectionadd[telegram]{socials}     {\protect\httpslink[#3]{t.me/#3}}}                              {}%
+      \ifthenelse{\equal{#1}{whatsapp}}     {\collectionadd[whatsapp]{socials}     {\protect\httpslink[#3]{wa.me/#3}}}                             {}%
+      \ifthenelse{\equal{#1}{signal}}       {\collectionadd[signal]{socials}       {#3}}                                                           {}%
+      \ifthenelse{\equal{#1}{matrix}}       {\collectionadd[matrix]{socials}       {\httpslink[#3]{matrix.to/\#/#3}}}                              {}%
       \ifthenelse{\equal{#1}{googlescholar}}{\collectionadd[googlescholar]{socials}{\protect\httpslink[#3]{scholar.google.com/citations?user=#3}}} {}%                        {}%
       }
     {\collectionadd[#1]{socials}{\protect\httpslink[#3]{#2}}}}%
@@ -341,6 +344,9 @@
 \newcommand*{\researcheridsocialsymbol} {}
 \newcommand*{\googlescholarsocialsymbol}{}
 \newcommand*{\telegramsocialsymbol}     {}
+\newcommand*{\whatsappsocialsymbol}     {}
+\newcommand*{\matrixsocialsymbol}       {}
+\newcommand*{\signalsocialsymbol}       {}
 
 % other
 %------

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -48,6 +48,10 @@
 \renewcommand*{\researcheridsocialsymbol} {{\small\aiResearcherID}~}       % alternative: \aiResearcherIDSquare 
 \renewcommand*{\telegramsocialsymbol}     {{\small\faTelegram}~}
 \renewcommand*{\googlescholarsocialsymbol}{{\small\aiGoogleScholar}~}
+\renewcommand*{\telegramsocialsymbol}     {{\small\faTelegram}~}
+\renewcommand*{\whatsappsocialsymbol}     {{\small\faWhatsapp}~}
+\renewcommand*{\signalsocialsymbol}       {}
+\renewcommand*{\matrixsocialsymbol}       {}
 
 \endinput
 

--- a/moderncviconsletters.sty
+++ b/moderncviconsletters.sty
@@ -52,6 +52,9 @@
 \renewcommand*{\researchgatesocialsymbol} {\textbf{rg}~}
 \renewcommand*{\researcheridsocialsymbol} {\textbf{ri}~}
 \renewcommand*{\telegramsocialsymbol}     {\textbf{tg}~}
+\renewcommand*{\whatsappsocialsymbol}     {\textbf{wa}~}
+\renewcommand*{\signalsocialsymbol}       {\textbf{si}~}
+\renewcommand*{\matrixsocialsymbol}       {\textbf{ma}~}
 \renewcommand*{\googlescholarsocialsymbol}{\textbf{gs}~}
 
 \renewcommand*{\listitemsymbol}      {\labelitemi~}

--- a/moderncviconsmarvosym.sty
+++ b/moderncviconsmarvosym.sty
@@ -227,6 +227,9 @@
 \renewcommand*{\stackoverflowsocialsymbol}{}
 \renewcommand*{\googlescholarsocialsymbol}{}
 \renewcommand*{\telegramsocialsymbol}{}
+\renewcommand*{\whatsappsocialsymbol}{}
+\renewcommand*{\signalsocialsymbol}{}
+\renewcommand*{\matrixsocialsymbol}{}
 \renewcommand*{\orcidsocialsymbol}{}
 \renewcommand*{\researchgatesocialsymbol}{}
 \renewcommand*{\researcheridsocialsymbol}{}

--- a/template.tex
+++ b/template.tex
@@ -35,7 +35,7 @@
 
 % Social icons
 \social[linkedin]{john.doe}                        % optional, remove / comment the line if not wanted
-\social[xing]{john\_doe}                           % optional, remove / comment the line if not wanted
+\social[xing]{john_doe}                           % optional, remove / comment the line if not wanted
 \social[twitter]{jdoe}                             % optional, remove / comment the line if not wanted
 \social[github]{jdoe}                              % optional, remove / comment the line if not wanted
 \social[gitlab]{jdoe}                              % optional, remove / comment the line if not wanted
@@ -46,7 +46,10 @@
 \social[researchgate]{jdoe}                        % optional, remove / comment the line if not wanted
 \social[researcherid]{jdoe}                        % optional, remove / comment the line if not wanted
 \social[telegram]{jdoe}                            % optional, remove / comment the line if not wanted
-\social[googlescholar]{googlescholarid}                % optional, remove / comment the line if not wanted
+\social[whatsapp]{12345678901}                     % optional, remove / comment the line if not wanted
+\social[signal]{12345678901}                       % optional, remove / comment the line if not wanted
+\social[matrix]{@johndoe:matrix.org}               % optional, remove / comment the line if not wanted
+\social[googlescholar]{googlescholarid}            % optional, remove / comment the line if not wanted
 
 
 \extrainfo{additional information}                 % optional, remove / comment the line if not wanted


### PR DESCRIPTION
Add social fields for WhatsApp, Signal, and Matrix.
Add WhatsApp icon; [Signal](https://github.com/FortAwesome/Font-Awesome/issues/7434) and [Matrix](https://github.com/FortAwesome/Font-Awesome/issues/12808) icons should be available in near-future via FontAwesomem already available in ForkAwesome, but no LaTeX bindings