### PR TITLE
Introduce makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@
 *.out
 *.pdf
 *.kate-swp
-*.synctex.gz
 *.toc
+*.synctex.gz
 
 # release tarballs
 moderncv-*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,10 @@
 *.pdf
 *.kate-swp
 *.synctex.gz
+*.toc
 
 # release tarballs
 moderncv-*.tar.gz
+*.gz
 
 examples/

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,11 @@
 *.fls
 *.log
 *.out
+*.pdf
+*.kate-swp
 *.synctex.gz
-
-# template.tex output
-# move to *.pdf once manual is done
-template.pdf
 
 # release tarballs
 moderncv-*.tar.gz
+
+examples/

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ MANUALDIR = $(MODERNCVDIR)/manual
 
 # version and date of the current release. This gets updated upon calling
 # either the rule version or the rule release
-VERSION = v2.1.0
-VERSIONDATE = 2021/01/21
+VERSION = v2.1.0-40-gfe4d968-dirty
+VERSIONDATE = 2021/01/25
 # user callable NEW option, to specify the new version. If unspecified, the
 # new version gets determined by git.
 ifdef NEW
     VERSIONNEXT = $(NEW)
 else
-    VERSIONNEXT = $(shell git describe --tags)
+    VERSIONNEXT = $(shell git describe --tags --dirty)
 endif
 VERSIONDATENEXT = $(shell date +"%Y\/%m\/%d")
 TARBALL=moderncv-$(VERSIONNEXT).tar
@@ -97,6 +97,8 @@ version:
 				if [[ -f "$$file" ]] && [[ ! -h "$$file" ]]; then
 					echo "updating version info of file $$file to $(VERSIONNEXT) (was $(VERSION))";
 					sed -i "s/$$findstr/$$replacestr/g" $$file;
+					# update version info in the title of documentation
+					sed -i "s/Package version $(VERSION)}/Package version $(VERSIONNEXT)}/g" $$file;
 				fi
 			done
 		done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,140 @@
+.ONESHELL:
+SHELL := /bin/bash
+MODERNCVDIR =.
+MANUALDIR = $(MODERNCVDIR)/manual
+
+# version and date of the current release. This gets updated upon calling
+# either the rule version or the rule release
+VERSION = v2.1.0
+VERSIONDATE = 2021/01/21
+# user callable NEW option, to specify the new version. If unspecified, the
+# new version gets determined by git.
+ifdef NEW
+    VERSIONNEXT = $(NEW)
+else
+    VERSIONNEXT = $(shell git describe --tags)
+endif
+VERSIONDATENEXT = $(shell date +"%Y\/%m\/%d")
+TARBALL=moderncv-$(VERSIONNEXT).tar
+
+EXAMPLESDIR = examples
+MANUAL = $(MANUALDIR)/moderncv_userguide.tex
+TEMPLATE = $(MODERNCVDIR)/template.tex
+TEMPLATEBIB = publications.bib
+TEMPLATEBASE = $(basename $(TEMPLATE))
+TEMPLATEPDF = $(addsuffix .pdf,$(TEMPLATEBASE))
+MANUAL_BASE = $(basename $(MANUAL))
+MANUALPDF = $(addsuffix .pdf,$(MANUAL_BASE))
+
+
+template: $(TEMPLATE) $(TEMPLATEBIB)
+	# build default template
+	latexmk -pdflua -bibtex -quiet "$<"
+
+
+templates: $(TEMPLATE) $(TEMPLATEBIB)
+	# build the template for each style and store pdfs in the examples folder
+	# this is done to include these expamples in release tar balls.
+	mkdir -p $(EXAMPLESDIR)
+	previousstyle="casual"
+	for style in casual classic banking oldstyle fancy; do
+		sedstring="s/moderncvstyle{$$previousstyle}/moderncvstyle{$$style}/g"
+		sed -i $$sedstring $(TEMPLATE)
+		latexmk -pdflua -bibtex -quiet $(TEMPLATE)
+		cp $(TEMPLATEPDF) $(EXAMPLESDIR)/$(TEMPLATEBASE)-$$style.pdf
+		mv $(TEMPLATEPDF) $(MANUALDIR)/$(TEMPLATEBASE)-$$style.pdf
+		previousstyle=$$style
+		unset sedstring
+	done
+	sedstring="s/moderncvstyle{$$previousstyle}/moderncvstyle{casual}/g"
+	sed -i $$sedstring $(TEMPLATE)
+
+
+userguide: templates $(MANUAL)
+	# build the user guide. Since the guide includes the template examples, we
+	# build those first by calling the templates rule.
+	lualatex --output-directory=$(MANUALDIR) $(MANUAL)
+	lualatex --output-directory=$(MANUALDIR) $(MANUAL)
+
+
+version:
+	# Upate version information and date of all moderncv files. A call make version
+	# will define VERSIONNEXT=$(shell git describe --tags). Alternatively, call
+	# "make version NEW=v5.13.298" to set v5.13.298 as the new version number.
+	# The date gets calculated by the date function.
+	if [[ $(strip $(VERSION)) == $(strip $(VERSIONNEXT)) ]]; then
+		echo "Old version number $(VERSION)  same as new version number $(VERSIONNEXT)"
+		echo "nothing to do, aborting."
+	else
+		# we need to split the $(VERSION) date format into substrings to using
+		# sed. This is due to / being a special character in sed.
+		YEAR=$(shell echo $(VERSIONDATE) | cut -d "/" -f 1)
+		MONTH=$(shell echo $(VERSIONDATE) | cut -d "/" -f 2)
+		DAY=$(shell echo $(VERSIONDATE) | cut -d "/" -f 3)
+		# update version info and date of *.sty, *.cls and *.tex files
+		# prepare find and replace with sed
+		findstr="$$YEAR\\/$$MONTH\\/$$DAY $(VERSION)"
+		replacestr="$(VERSIONDATENEXT) $(VERSIONNEXT)"
+		for currentdir in $(MODERNCVDIR) $(MANUALDIR); do
+			for file in $$currentdir/*.cls $$currentdir/*.sty $$currentdir/*.tex; do
+				if [[ -f "$$file" ]] && [[ ! -h "$$file" ]]; then
+					echo "updating version info of file $$file to $(VERSIONNEXT) (was $(VERSION))";
+					sed -i "s/$$findstr/$$replacestr/g" $$file;
+				fi
+			done
+		done
+		unset findstr; unset replacestr
+		# update VERSION and VERSIONDATE variable of this very file
+		sed -i "s/VERSION = $(VERSION)/VERSION = $(VERSIONNEXT)/g" $(MODERNCVDIR)/Makefile
+		findstr="VERSIONDATE = $$YEAR\\/$$MONTH\\/$$DAY"
+		replacestr="VERSIONDATE = $(shell date +"%Y")\\/$(shell date +"%m")\\/$(shell date +"%d")"
+		sed -i "s/$$findstr/$$replacestr/g" $(MODERNCVDIR)/Makefile
+		unset findstr; unset replacestr
+	fi
+
+tarball:
+	# build a tarball for release puposes. If the examples directory exist,
+	# include them
+	# remove existing tarballs
+	rm -f *.gz *.tar
+	# create tar with all files in git repo
+	git archive HEAD > $(TARBALL)
+	# remove git specific files
+	tar -f $(TARBALL) --delete .github/ .gitignore create-release-tarball.sh
+	# if examples exist include them in the tarball
+	if [[ -d "$(EXAMPLESDIR)" ]]; then
+		tar -rf $(TARBALL) --append $(EXAMPLESDIR)
+	fi
+	# include precompiled template pdfs and userguide from manual folder,
+	# the idea being that the userguide can be build from the manual folder
+	# and has everything that it needs to compile. If the release method gets
+	# called this ensures that a precompiled version of the userguide is
+	# included in the tar ball.
+	tar -rf $(TARBALL) --append $(MANUALDIR)
+	# compress
+	gzip $(TARBALL)
+
+release: userguide version clean tarball
+
+#.PHONY: clean
+clean:
+	for dir in $(MODERNCVDIR) $(MANUALDIR); do
+		echo cleaning directory $$dir
+		cd $$dir/
+		rm -fv *.acn *.acr *.alg *.aux *.bcf *.blg *.dvi *.fdb_latexmk *.fls;
+		rm -fv *.glg *.idx *.ilg *.ist *.spl *.lof *.log *.lot *.out *.pdfsync;
+		rm -fv *.run.xml *.snm *.synctex.gz *.tdo *.toc *.vrb *blx.bib *~;
+		if [[ "$$dir" != "." ]]; then
+			cd ..
+		fi
+	done
+
+delete:
+	rm -fv $(TEMPLATEPDF)
+	rm -fv $(MANUALPDF)
+
+deleteexamples:
+	rm -rfv $(EXAMPLESDIR)
+	rm -fv $(MANUALDIR)/*.pdf
+
+force:  delete deleteexamples userguide clean

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,12 @@ VERSIONDATENEXT = $(shell date +"%Y\/%m\/%d")
 TARBALL=moderncv-$(VERSIONNEXT).tar
 
 EXAMPLESDIR = examples
-MANUAL = $(MANUALDIR)/moderncv_userguide.tex
+# MANUALTEX is used by the userguide method that operates in the 
+# $(MANUALDIR) folder. MANUAL is used by methods operating in 
+# the $(MODERNCVDIR) folder. This is to ensuer that the userguide 
+# is also buildable within the manual folder.
+MANUALTEX = moderncv_userguide.tex
+MANUAL = $(MANUALDIR)/$(MANUALTEX)
 TEMPLATE = $(MODERNCVDIR)/template.tex
 TEMPLATEBIB = publications.bib
 TEMPLATEBASE = $(basename $(TEMPLATE))
@@ -70,8 +75,11 @@ templates: $(TEMPLATE) $(TEMPLATEBIB)
 userguide: templates $(MANUAL)
 	# build the user guide. Since the guide includes the template examples, we
 	# build those first by calling the templates rule.
-	lualatex --output-directory=$(MANUALDIR) $(MANUAL)
-	lualatex --output-directory=$(MANUALDIR) $(MANUAL)
+	cd $(MANUALDIR)
+	./format_files_for_userguide.py 
+	lualatex $(MANUALTEX)
+	lualatex $(MANUALTEX)
+	cd ..
 
 
 version:

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,27 @@ TEMPLATEPDF = $(addsuffix .pdf,$(TEMPLATEBASE))
 MANUAL_BASE = $(basename $(MANUAL))
 MANUALPDF = $(addsuffix .pdf,$(MANUAL_BASE))
 
-
+# redefine the template rule depending on whether the user has specified STYLE
+# or not.
+ifdef STYLE
+	# in this case user has specified STYLE
+else
+	STYLE = casual
+endif
 template: $(TEMPLATE) $(TEMPLATEBIB)
-	# build default template
-	latexmk -pdflua -bibtex -quiet "$<"
+	if [[ $(strip $(STYLE)) == "casual" ]]; then
+		# build template in default style
+		latexmk -pdflua -bibtex -quiet "$<"
+	else
+		# build template in style $(STYLE). This assumes that casual is the default.
+		sedstring="s/moderncvstyle{casual}/moderncvstyle{$(STYLE)}/g"
+		sed -i $$sedstring $(TEMPLATE)
+		# build template in specified style
+		latexmk -pdflua -bibtex -quiet "$<"
+		# reset template to default value
+		sedstring="s/moderncvstyle{$(STYLE)}/moderncvstyle{casual}/g"
+		sed -i $$sedstring $(TEMPLATE)
+	fi
 
 
 templates: $(TEMPLATE) $(TEMPLATEBIB)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ The user guide can be found in the folder `manual` and contains additional infor
 The `Makefile` supports the following rules.
 
 #### Rules intended for regular use
-* `template:` Build the default `moderncv` template `template.tex` with `LuaLaTeX`.
+* `template:` Build the `moderncv` template `template.tex` with `LuaLaTeX`. This rule can be called in one of two ways: 
+  * `make template`: Build the template in casual style.
+  * `make template STYLE=<style>`: Build the template in the style specified by
+	`<style>`. `<style>` can be classic, casual, banking, oldstyle or fancy.
 
 * `templates:` Build the template `template.tex` with LuaLaTeX for _all moderncv styles_ and move resulting `pdf` files to the folder `examples/`.
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,52 @@
 
 ## A modern curriculum vitae class for LaTeX
 
-**moderncv** provides a documentclass for typesetting curricula vitae in various styles. Moderncv aims to be both straightforward to use and customizable, providing five ready-made styles (classic, casual, banking, oldstyle and fancy) and allowing one to define his own by modifying colors, fonts, icons, etc.
+`moderncv` provides a documentclass for typesetting applications (curricula vitae and cover letters) in various styles. `moderncv` aims to be both straightforward to use and customizable, providing five ready-made styles (classic, casual, banking, oldstyle and fancy) and allowing one to define his own by modifying colors, fonts, icons, etc.
 
-Most commands are defined in such a way that arguments are optional.
+### Getting started 
+Once you clone this repo have a look at some examples and build the manual to see if this package suits your needs.
+This can be done by issuing 
+```make
+make userguide
+```
+in a terminal. After completion of the compilation precompiled versions of the template in all styles can be found in the folder `examples` and 
+the user guide in the folder `manual`.  
+Alternatively get the tar ball from [CTAN](https://ctan.org/pkg/moderncv?lang=de). The examples as well as the documentation are already prebuilt in that tarball.
 
-Until a decent manual is written, one can always look in the `template.tex` file for an example. It can be compiled to pdf via `latexmk -pdf ./template.tex`.
+To start working on your own application use and modify the template file `template.tex`.
+The user guide can be found in the folder `manual` and contains additional information on what the document class offers.
+
+### Makefile
+The `Makefile` supports the following rules.
+
+#### Rules intended for regular use
+* `template:` Build the default `moderncv` template `template.tex` with `LuaLaTeX`.
+
+* `templates:` Build the template `template.tex` with LuaLaTeX for _all moderncv styles_ and move resulting `pdf` files to the folder `examples/`.
+
+* `userguide:`  Build the user manual `manual/moderncv_userguide.tex` with `LuaLaTeX`. This rule calls the rule `templates` before compiling the documentation.
+
+* `clean:` Clean the clutter created by compiling of the documents.
+
+* `delete:`Delete `template.pdf` and `manual/moderncv_userguide.pdf`.
+
+* `deleteexamples:` Delete `examples/` folder and remaining template example `pdf` files in folder `manual/`.
+
+* `force:`  Force rebuilding the user guide by running the rules `delete` `deleteexamples`  `userguide` and clean `clean
+
+#### Rules intended for package maintainers
+* `version:` Update the version information (version number and date) of all `moderncv` files (*.sty, moderncv.cls, *.tex). This rule can be called in two different ways. Note, however, that it is intended to be called by the rule `release` and usually does not need to be called explicitly.
+  * `make version:` Called in this way the version number is obtained through `git describe --tags`. If this information is newer all `moderncv` files get updated. 
+  * `make version NEW=<version number>:` Optionally, the desired version number `<version number>` can be specified. 
+
+* `tarball:`  Create a new release tarball suitable for upload to CTAN. If the `example/` folder is present, it gets included in the tar archive. Similary, all `pdf` files in the `manual/` folder get included aswell. This rule is intended to be called by the rule `release` and usually does not need to be called explicitly.
+
+* `release:`Update the version information, rebuild examples as well as the user guide and create a releasable tarball including everything. In this way the tarball on CTAN contains ready made pdf files.  
+
+
 
 ## Licence
-moderncv is licensed under the [LPPL-1.3c](https://spdx.org/licenses/LPPL-1.3c.html).
+`moderncv` is licensed under the [LPPL-1.3c](https://spdx.org/licenses/LPPL-1.3c.html).
 
 ## Origin
 Original author: Xavier Danaux <xdanaux@gmail.com><br/>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The user guide can be found in the folder `manual` and contains additional infor
 ### Makefile
 The `Makefile` supports the following rules.
 
-#### Rules intended for regular use
+#### Rules for building templates and the user guide
 * `template:` Build the `moderncv` template `template.tex` with `LuaLaTeX`. This rule can be called in one of two ways: 
   * `make template`: Build the template in casual style.
   * `make template STYLE=<style>`: Build the template in the style specified by
@@ -38,15 +38,18 @@ The `Makefile` supports the following rules.
 
 * `force:`  Force rebuilding the user guide by running the rules `delete` `deleteexamples`  `userguide` and clean `clean
 
-#### Rules intended for package maintainers
+#### Rules intended for package maintainance
 * `version:` Update the version information (version number and date) of all `moderncv` files (*.sty, moderncv.cls, *.tex). This rule can be called in two different ways. Note, however, that it is intended to be called by the rule `release` and usually does not need to be called explicitly.
   * `make version:` Called in this way the version number is obtained through `git describe --tags`. If this information is newer all `moderncv` files get updated. 
   * `make version NEW=<version number>:` Optionally, the desired version number `<version number>` can be specified. 
 
 * `tarball:`  Create a new release tarball suitable for upload to CTAN. If the `example/` folder is present, it gets included in the tar archive. Similary, all `pdf` files in the `manual/` folder get included aswell. This rule is intended to be called by the rule `release` and usually does not need to be called explicitly.
 
-* `release:`Update the version information, rebuild examples as well as the user guide and create a releasable tarball including everything. In this way the tarball on CTAN contains ready made pdf files.  
-
+* `release:`Update the version information of all files including the subtitle
+  in the user guide, rebuild examples as well as the user
+  guide and create a releasable tarball including the copiled pdfs. 
+  Before runing `make release` for an actual release be sure to tag the last
+  commit with the intended version information.
 
 
 ## Licence

--- a/manual/format_files_for_userguide.py
+++ b/manual/format_files_for_userguide.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import os
+
+def create_texlist(path_to_reader: str,
+                   path_to_writer: str,
+                   list_type: str) -> None:
+    readerpath = path_to_reader
+    writerpath = path_to_writer
+    try:
+        f = open(readerpath,'r')
+    except OSError:
+        raise RuntimeError(f'Failed to open file {readerpath}.')
+    else:
+        f.close()
+
+    # remove old file
+    if os.path.exists(writerpath):
+        os.remove(writerpath)
+    with open(readerpath,'r') as reader, open(writerpath,'w') as writer:
+        writer.write('\\begin{'+f'{list_type}'+'}\n')
+        wholefile = reader.read()
+        # clean out latex commands
+        wholefile = wholefile.replace(' \\',' {\\textbackslash}')
+        sentences = wholefile.split('- ')
+        for sentence in sentences:
+            if sentence != '':
+                # writer.write('\n')
+                writer.write(f'    \item {sentence}')
+
+        writer.write('\end{'+f'{list_type}'+'}')
+
+def main():
+    kb_path = '../KNOWN_BUGS'
+    kb_tex_path = 'known_bugs.tex'
+
+    create_texlist(path_to_reader=kb_path,
+                   path_to_writer=kb_tex_path,
+                   list_type='enumerate')
+
+if __name__== "__main__":
+   main()


### PR DESCRIPTION
Indroduction of the makefile now with clean rebase. 
I suggest postponing changing the scripts for adding the iso date formate to later until all changes have been merged. 

These changes introduce the first batch of make automations for building the user guide as well as creating release tar balls. 
 
New rules (one, don't pick up the phone, two ...):

### Makefile
The `Makefile` supports the following rules.

#### Rules intended for regular use
* `template:` Build the `moderncv` template `template.tex` with `LuaLaTeX`. This rule can be called in one of two ways: 
  * `make template`: Build the template in casual style.
  * `make template STYLE=<style>`: Build the template in the style specified by
	`<style>`. `<style>` can be classic, casual, banking, oldstyle or fancy.

* `templates:` Build the template `template.tex` with LuaLaTeX for _all moderncv styles_ and move resulting `pdf` files to the folder `examples/`.

* `userguide:`  Build the user manual `manual/moderncv_userguide.tex` with `LuaLaTeX`. This rule calls the rule `templates` before compiling the documentation.

* `clean:` Clean the clutter created by compiling of the documents.

* `delete:`Delete `template.pdf` and `manual/moderncv_userguide.pdf`.

* `deleteexamples:` Delete `examples/` folder and remaining template example `pdf` files in folder `manual/`.

* `force:`  Force rebuilding the user guide by running the rules `delete` `deleteexamples`  `userguide` and clean `clean
#### Rules intended for package maintainers
* `version:` Update the version information (version number and date) of all `moderncv` files (*.sty, moderncv.cls, *.tex). This rule can be called in two different ways. Note, however, that it is intended to be called by the rule `release` and usually does not need to be called explicitly.
  * `make version:` Called in this way the version number is obtained through `git describe --tags`. If this information is newer all `moderncv` files get updated. 
  * `make version NEW=<version number>:` Optionally, the desired version number `<version number>` can be specified. 
* `tarball:`  Create a new release tarball suitable for upload to CTAN. If the `example/` folder is present, it gets included in the tar archive. Similary, all `pdf` files in the `manual/` folder get included aswell. This rule is intended to be called by the rule `release` and usually does not need to be called explicitly.
* `release:`Update the version information, rebuild examples as well as the user guide and create a releasable tarball including everything. In this way the tarball on CTAN contains ready made pdf files.  