### PR TITLE
Fix extra new line after address in style banking

### DIFF
--- a/moderncvheadiii.sty
+++ b/moderncvheadiii.sty
@@ -90,7 +90,7 @@
       \ifthenelse{\isundefined{\@addressstreet}}{}{\addtomakeheaddetails{\addresssymbol\@addressstreet}%
         \ifthenelse{\equal{\@addresscity}{}}{}{\addtomakeheaddetails[~--~]{\@addresscity}}% if \addresstreet is defined, \addresscity and \addresscountry will always be defined but could be empty
         \ifthenelse{\equal{\@addresscountry}{}}{}{\addtomakeheaddetails[~--~]{\@addresscountry}}%
-        \flushmakeheaddetails\@firstmakeheaddetailselementtrue\\\null}%
+        \flushmakeheaddetails\@firstmakeheaddetailselementtrue\\}%
       \ifthenelse{\isundefined{\@born}}{}{\addtomakeheaddetails{\bornsymbol\@born}}%
       \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
         \addtomakeheaddetails{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%


### PR DESCRIPTION
fix(moderncvheadiii.sty): remove /null at the end of the address header.
This removes the unnecessary newline there.