### PR TITLE
Move space after title into conditional

### DIFF
--- a/moderncvheadv.sty
+++ b/moderncvheadv.sty
@@ -92,11 +92,16 @@
       \newlength{\makecvheadpictureboxskip}%
       \setlength{\makecvheadpictureboxskip}{\totalheightof{\usebox{\makecvheadpicturebox}}}%
       \namestyle{\@firstname\ \@lastname}%
-      \ifthenelse{\equal{\@title}{}}{}{\\[1.25em]\titlestyle{\@title}\\[2.5em]}%
-      % optional quote
-      \ifthenelse{\isundefined{\@quote}}%
-        {}%
-        {\begin{minipage}{\quotewidth}\quotestyle{\@quote}\end{minipage}\\[2.5em]}}%
+	  \ifthenelse{\equal{\@title}{}}{
+	    \ifthenelse{\isundefined{\@quote}}%
+          {}%
+          {\\[1.25em]\begin{minipage}{\quotewidth}\quotestyle{\@quote}\end{minipage}\\[2.5em]}
+	    }{
+	    \\[1.25em]\titlestyle{\@title}\\[2.5em]%
+        % optional quote
+        \ifthenelse{\isundefined{\@quote}}%
+          {}%
+          {\begin{minipage}{\quotewidth}\quotestyle{\@quote}\end{minipage}\\[2.5em]}}}%
   \par}% to avoid weird spacing bug at the first section if no blank line is left after \makecvhead
 
 % underlying command to implement \makecvtitle, identical to \@cvitem from moderncvbodyv

--- a/moderncvheadv.sty
+++ b/moderncvheadv.sty
@@ -92,7 +92,7 @@
       \newlength{\makecvheadpictureboxskip}%
       \setlength{\makecvheadpictureboxskip}{\totalheightof{\usebox{\makecvheadpicturebox}}}%
       \namestyle{\@firstname\ \@lastname}%
-      \ifthenelse{\equal{\@title}{}}{}{\\[1.25em]\titlestyle{\@title}}\\[2.5em]%
+      \ifthenelse{\equal{\@title}{}}{}{\\[1.25em]\titlestyle{\@title}\\[2.5em]}%
       % optional quote
       \ifthenelse{\isundefined{\@quote}}%
         {}%


### PR DESCRIPTION
Fixes the extra space below the name in the fancy style header.

The extra space should be visible in the following example:
```
\documentclass[roman]{moderncv}
\moderncvstyle{fancy}

\name{John}{Doe}
\phone[mobile]{+1~(234)~567~890}
\email{john@doe.org}

\begin{document}
\makecvtitle
\end{document}
```