### PR TITLE
Major Bug Fix for non-English Characters

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -117,15 +117,12 @@
 %     \RequirePackage[utf8]{inputenx}
 %     %additions for utf8
 %     \input{ix-utf8enc.dfu}
-    \RequirePackage[T1]{fontenc}
-    % loading lmodern can cause issues with certain special characters. avoid. 
-%     \IfFileExists{lmodern.sty}%
-%         {\RequirePackage{lmodern}}%
-%         {}
+    %\RequirePackage[T1]{fontenc}
 %     \fi
 \fi
 
 \RequirePackage[T1]{fontenc}
+% loading lmodern can cause issues with certain special characters
 \IfFileExists{lmodern.sty}%
   {\RequirePackage{lmodern}}%
   {}

--- a/moderncv.cls
+++ b/moderncv.cls
@@ -96,10 +96,11 @@
   \fi
 \fi
 
-% do not use inputenc and do not automatically load lmodern to avoid problems with German 
-% charactes, see
-% https://tex.stackexchange.com/questions/496630/lualatex-problems-with-german-characters
+% Using inputenc and do automatically loading lmodern leads to problems with German 
+% characters. (https://tex.stackexchange.com/questions/496630/lualatex-problems-with-german-characters)
+% However, the fix rendered characters from other languages (e.g. Greek) unusable.
 \ifxetexorluatex
+      % Automatic loading of latin modern fonts
 %     \RequirePackage{fontspec}
 %     \defaultfontfeatures{Ligatures=TeX}
 %     \RequirePackage{unicode-math}
@@ -123,6 +124,12 @@
 %         {}
 %     \fi
 \fi
+
+\RequirePackage[T1]{fontenc}
+\IfFileExists{lmodern.sty}%
+  {\RequirePackage{lmodern}}%
+  {}
+
 % hyper links (hyperref is loaded at the end of the preamble to pass options required by loaded packages such as CJK)
 \newcommand*\pdfpagemode{UseNone}% do not show thumbnails or bookmarks on opening (on supporting browsers); set \pdfpagemode to "UseOutlines" to show bookmarks
 \RequirePackage{url}


### PR DESCRIPTION
Certain non-English characters cannot be compiled at all since commit caa0cb8.

For example, even when using commands such as `\usepackage{fontspec}`, a Missing Character error is always raised:
```tex
Missing character: There is no π in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no υ in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no ρ in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no ί in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no δ in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no ω in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no ν in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no α in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no ρ in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no δ in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no ά in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no κ in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no η in font [lmroman17-regular]:mapping=tex-text;!
Missing character: There is no ς in font [lmroman17-regular]:mapping=tex-text;!
```

Solution: Revert some of the changes that were performed in the aforementioned commit.