### PR TITLE
Try to mimic previous fontawesome look with fontawesome5

### DIFF
--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -24,36 +24,36 @@
 %-------------------------------------------------------------------------------
 %                symbols definition
 %-------------------------------------------------------------------------------
-\renewcommand*{\labelitemi}          {\strut\textcolor{color1}{\tiny\faCircle}}
+\renewcommand*{\labelitemi}          {\strut\textcolor{color1}{\tiny\faCircle[regular]}} % alternative: \faCircle (solid style)
 %\renewcommand*{\labelitemii}         {\strut\textcolor{color1}{\large\bfseries-}}            % no change from default in moderncv.cls
 %\renewcommand*{\labelitemiii}        {\strut\textcolor{color1}{\rmfamily\textperiodcentered}}% no change from default in moderncv.cls
 %\renewcommand*{\labelitemiv}         {\labelitemiii}                                         % no change from default in moderncv.cls
 
 
 \renewcommand*{\addresssymbol}            {}
-\renewcommand*{\mobilephonesymbol}        {{\small\faMobile}~}
-\renewcommand*{\fixedphonesymbol}         {{\small\faPhone}~}
+\renewcommand*{\mobilephonesymbol}        {{\small\faMobile*}~}            % alternative: \faMobile (solid style)
+\renewcommand*{\fixedphonesymbol}         {{\small\faPhone*}~}             % alternative: \faPhone (reversed)
 \renewcommand*{\faxphonesymbol}           {{\small\faFax}~}                % alternative: \faPrint
-\renewcommand*{\emailsymbol}              {{\small\faEnvelope}~}           % alternative: \faInbox
-\renewcommand*{\homepagesymbol}           {{\small\faGlobe}~}              % alternative: \faHome
-\renewcommand*{\linkedinsocialsymbol}     {{\small\faLinkedin}~}           % alternative: \faLinkedinSquare
+\renewcommand*{\emailsymbol}              {{\small\faEnvelope[regular]}~}  % alternative: \faInbox, \faEnvelope (solid style)
+\renewcommand*{\homepagesymbol}           {{\small\faGlobeAmericas}~}      % alternative: \faHome, \faGlobe, \faGlobeEurope, \faGlobeAfrica, \faGlobeAsia
+\renewcommand*{\linkedinsocialsymbol}     {{\small\faLinkedinIn}~}         % alternative: \faLinkedin
 \renewcommand*{\xingsocialsymbol}         {{\small\faXing}~}               % alternative: \faXingSquare
 \renewcommand*{\twittersocialsymbol}      {{\small\faTwitter}~}            % alternative: \faTwitterSquare
-\renewcommand*{\githubsocialsymbol}       {{\small\faGithub}~}             % alternative: \faGithubSquare, \faGithubSquare
+\renewcommand*{\githubsocialsymbol}       {{\small\faGithub}~}             % alternative: \faGithubSquare, \faGithub*
 \renewcommand*{\gitlabsocialsymbol}       {{\small\faGitlab}~}
 \renewcommand*{\stackoverflowsocialsymbol}{{\small\faStackOverflow}~}
 \renewcommand*{\bitbucketsocialsymbol}    {{\small\faBitbucket}~}
 \renewcommand*{\skypesocialsymbol}        {{\small\faSkype}~}
 \renewcommand*{\orcidsocialsymbol}        {{\small\aiOrcid}~}
 \renewcommand*{\researchgatesocialsymbol} {{\small\aiResearchGate}~}
-\renewcommand*{\researcheridsocialsymbol} {{\small\aiResearcherID}~}       % alternative: \aiResearcherIDSquare 
+\renewcommand*{\researcheridsocialsymbol} {{\small\aiResearcherID}~}       % alternative: \aiResearcherIDSquare
 \renewcommand*{\telegramsocialsymbol}     {{\small\faTelegram}~}
 \renewcommand*{\googlescholarsocialsymbol}{{\small\aiGoogleScholar}~}
 \renewcommand*{\telegramsocialsymbol}     {{\small\faTelegram}~}
 \renewcommand*{\whatsappsocialsymbol}     {{\small\faWhatsapp}~}
 \renewcommand*{\signalsocialsymbol}       {}
 \renewcommand*{\matrixsocialsymbol}       {}
-\renewcommand*{\bornsymbol}               {{\small\faAsterisk}~}
+\renewcommand*{\bornsymbol}               {{\small\faAsterisk}~}           % alternative: \faBabyCarriage
 
 \endinput
 


### PR DESCRIPTION
This MR  fixes #67.

For memory purpose, here is a screenshot of the default `template.tex` in the pre-fontawesome5 era:

![moderncv_before](https://user-images.githubusercontent.com/349239/129256396-e6376180-ebea-44d3-9c32-3d2c4469a77d.png)

The following screenshot shows how the icons look now by default with fontawesome5. As we can see, they are using sort of *solid* icon style.

![moderncv_before2](https://user-images.githubusercontent.com/349239/129256397-d48d77e2-43c7-4ea7-9839-09b9622a5724.png)

The following screenshot show how the icons will look like with the current MR applied.

![moderncv_new](https://user-images.githubusercontent.com/349239/129256401-856caf0e-5a49-4af4-88d5-71c690df3690.png)

To summarize, the current MR change the following icons back to an *outline* style:

- first level list item bullet
- email default envelope icon
- mobile smartphone icon
- linkedin logo icon

It also makes the following changes:

- reverse the landline phone icon (turned to the right instead of to the left)
- change the homepage conceptual globe icon to an americas-centered geographical globe icon. Advertize the other geographic possibilities in the comment.

Finally this MR adds some invisible changes:

- propose `\faBabyCarriage` as an alternative to `\faAsterisk` for the birthdate icon in a comment
- fix alternative comment for linkedin icon (`\faLinkedinSquare` does not exist any more)
- fix alternative comment for github icon (`\faGithubSquare` was written twice instead of the new possibility `\faGithub*`). Default value does not change.
- remove a trailing space on the line 49 (`\researcheridsocialsymbol` icon)