### PR TITLE
Update README and add warning for required LaTex engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Most commands are defined in such a way that arguments are optional.
 
 Until a decent manual is written, one can always look in the `template.tex` file for an example. It can be compiled to pdf via `latexmk -pdf ./template.tex`.
 
-`moderncv` requires to be compiled with a Xe(La)TeX or Lua(La)TeX engine because it relies on [`academicons`]-https://ctan.org/tex-archive/fonts/academicons?lang=en).
+`moderncv` requires to be compiled with a Xe(La)TeX or Lua(La)TeX engine because it relies on [`academicons`]-https://ctan.org/tex-archive/fonts/academicons).
 
 ## Licence
 moderncv is licensed under the [LPPL-1.3c](https://spdx.org/licenses/LPPL-1.3c.html).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Most commands are defined in such a way that arguments are optional.
 
 Until a decent manual is written, one can always look in the `template.tex` file for an example. It can be compiled to pdf via `latexmk -pdf ./template.tex`.
 
+`moderncv` requires to be compiled with a Xe(La)TeX or Lua(La)TeX engine because it relies on [`academicons`]-https://ctan.org/tex-archive/fonts/academicons?lang=en).
+
 ## Licence
 moderncv is licensed under the [LPPL-1.3c](https://spdx.org/licenses/LPPL-1.3c.html).
 

--- a/moderncv.cls
+++ b/moderncv.cls
@@ -93,6 +93,7 @@
     \xetexorluatextrue
   \else
     \xetexorluatexfalse
+    \ClassWarningNoLine{moderncv}{"academicons requires xetex/luatex to work. Not all social icons might work properly."}
   \fi
 \fi
 


### PR DESCRIPTION
Describes which engines fully work with the package and why.

There has been several issues opened around people using `pdflatex` and other commands, that won't generate all symbols correctly.

Especially until the user manual is updated, but I think in general, we should clearly specify this upfront, just to avoid unnecessary confusion.