### PR TITLE
Update build-pdf.yml

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   build-template:
     name: Build template
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install TeX Live
         run: sudo apt install texlive-full fonts-font-awesome

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -10,8 +10,11 @@ jobs:
         run: sudo apt install texlive-full fonts-font-awesome
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Build pdf
-        run: latexmk -pdflua ./template.tex
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: ./template.tex
+          latexmk_use_lualatex: true
       - name: Scan log
         run: texloganalyser -wahv ./template.log
       - name: Upload pdf

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -7,14 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install TeX Live
-        run: sudo apt install texlive-full fonts-font-awesome
+        run: sudo apt update && sudo apt install texlive-full fonts-font-awesome
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Compile LaTeX document
-        uses: xu-cheng/latex-action@v2
-        with:
-          root_file: ./template.tex
-          latexmk_use_lualatex: true
+      - name: Build pdf
+        run: latexmk -pdflua ./template.tex
       - name: Scan log
         run: texloganalyser -wahv ./template.log
       - name: Upload pdf


### PR DESCRIPTION
It looks like the build system broke? See #82 

I'm proposing to move over to a github action to setup texlive and compile the files.
See https://github.com/marketplace/actions/github-action-for-latex

It still uses `latexmk` and it can be configured to use `LuaTex` so I think it should be identical to the current setup.

