### PR TITLE
Added \protect to tikz path in some icons 

### DIFF
--- a/moderncviconstikz.sty
+++ b/moderncviconstikz.sty
@@ -217,7 +217,7 @@
     \protect\raisebox{-0.12em}{
       \protect\begin{tikzpicture}[x=0.11em, y=0.11em, xscale=0.015, yscale=-0.015, inner sep=0pt, outer sep=0pt]
       \protect\begin{scope}[shift={(507,387)}]
-      \path[fill=color2,line width=0.057pt]
+      \protect\path[fill=color2,line width=0.057pt]
       (105.2000,24.9000) .. controls (102.1000,16.0000) and (89.5000,16.0000) .. 
       (86.3000,24.9000) -- (29.8000,199.7000) -- (161.7000,199.7000) .. controls
       (161.7000,199.7000) and (105.2000,24.9000) .. (105.2000,24.9000) -- cycle
@@ -274,7 +274,7 @@
     \protect\raisebox{-0.12em}{
     \protect\begin{tikzpicture}[x=0.11em, y=0.11em, xscale=0.015, yscale=-0.015, inner sep=0pt, outer sep=0pt]
     \protect\begin{scope}[shift={(507,387)}]
-    \path[fill=color2,line width=0.057pt]
+    \protect\path[fill=color2,line width=0.057pt]
     (105.2000,24.9000) .. controls (102.1000,16.0000) and (89.5000,16.0000) .. 
     (86.3000,24.9000) -- (29.8000,199.7000) -- (161.7000,199.7000) .. controls
     (161.7000,199.7000) and (105.2000,24.9000) .. (105.2000,24.9000) -- cycle
@@ -295,7 +295,7 @@
     \protect\raisebox{-0.12em}{
     \protect\begin{tikzpicture}[y=2.0pt, x=2.0pt, yscale=-0.1, xscale=0.1, inner sep=0pt, outer sep=0pt]
     \protect\begin{scope}[shift={(507,387)}]
-    \path[fill=color2] (25.0000,2.0000) .. controls (12.3095,2.0000) and (2.0000,12.3095)
+    \protect\path[fill=color2] (25.0000,2.0000) .. controls (12.3095,2.0000) and (2.0000,12.3095)
 		.. (2.0000,25.0000) .. controls (2.0000,37.6905) and (12.3095,48.0000) ..
 		(25.0000,48.0000) .. controls (37.6905,48.0000) and (48.0000,37.6905) ..
 		(48.0000,25.0000) .. controls (48.0000,12.3095) and (37.6905,2.0000) ..
@@ -348,7 +348,7 @@
     \protect\raisebox{-0.12em}{
     \protect\begin{tikzpicture}[y=1.8pt, x=1.8pt, yscale=-0.15, xscale=0.15, inner sep=0pt, outer sep=0pt]
     \protect\begin{scope}[shift={(507,387)}]
-    \path[fill=color2] 
+    \protect\path[fill=color2] 
       (0.9360,0.7320) .. controls (0.9360,10.9053) and (0.9360,21.0787) ..
       (0.9360,31.2520) .. controls (1.6673,31.2520) and (2.3987,31.2520) ..
       (3.1300,31.2520) .. controls (3.3452,32.0075) and (2.8778,32.0803) ..
@@ -395,7 +395,7 @@
     \protect\raisebox{-0.12em}{
     \protect\begin{tikzpicture}[y=0.1pt, x=0.1pt, yscale=-0.13, xscale=0.13, inner sep=0pt, outer sep=0pt]
     \protect\begin{scope}[shift={(507,387)}]
-    \path[fill=color2] 
+    \protect\path[fill=color2] 
       (430.1000,180.9000) -- (437.8000,211.9000) .. controls (407.6000,219.3000)
       and (378.7000,231.3000) .. (352.1000,247.3000) -- (335.7000,220.0000) ..
       controls (365.0000,202.3000) and (396.9000,189.1000) .. (430.1000,180.9000) --


### PR DESCRIPTION
Fix broken compilation in classic style.
Related to line 73 in moderncvheadi.sty (the head of classic)