### PR TITLE
Retokenize classic

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -513,14 +513,14 @@
 \newcommand*{\link}[2][]{%
   \ifthenelse{\equal{#1}{}}%
     {\href{#2}{#2}}%
-    {\href{#2}{\detokenize{#1}}}}
+    {\href{#2}{#1}}}
 
 % makes a http hyperlink
 % usage: \httplink[optional text]{link}
 \newcommand*{\httplink}[2][]{%
   \ifthenelse{\equal{#1}{}}%
     {\href{http://#2}{#2}}%
-    {\href{http://#2}{\detokenize{#1}}}}
+    {\href{http://#2}{#1}}}
 
 
 % makes an https hyperlink
@@ -528,14 +528,14 @@
 \newcommand*{\httpslink}[2][]{%
   \ifthenelse{\equal{#1}{}}%
     {\href{https://#2}{#2}}%
-    {\href{https://#2}{\detokenize{#1}}}}
+    {\href{https://#2}{#1}}}
 
 % makes an email hyperlink
 % usage: \emaillink[optional text]{link}
 \newcommand*{\emaillink}[2][]{%
   \ifthenelse{\equal{#1}{}}%
     {\href{mailto:#2}{#2}}%
-    {\href{mailto:#2}{\detokenize{#1}}}}
+    {\href{mailto:#2}{#1}}}
 
 % makes a tel hyperlink
 % usage: \tellink[optional text]{link}

--- a/template.tex
+++ b/template.tex
@@ -54,8 +54,8 @@
 
 % Social icons
 \social[linkedin]{john.doe}                        % optional, remove / comment the line if not wanted
-\social[xing]{john_doe}                           % optional, remove / comment the line if not wanted
-\social[twitter]{jdoe}                             % optional, remove / comment the line if not wanted
+\social[xing]{john\_doe}                           % optional, remove / comment the line if not wanted
+\social[twitter]{ji\_doe}                             % optional, remove / comment the line if not wanted
 \social[github]{jdoe}                              % optional, remove / comment the line if not wanted
 \social[gitlab]{jdoe}                              % optional, remove / comment the line if not wanted
 \social[stackoverflow]{0000000/johndoe}            % optional, remove / comment the line if not wanted


### PR DESCRIPTION
Closes #79 by removing `detokenize`; should also result in close #23: 

Please try to test the social links with whatever crazy nonsense you can think of and any other examples from #79:
I think all examples provided are now fine with pdfLaTeX and XeLaTeX, but a couple independent reviews would be great

Please also check if the combination of pdfLaTeX, classic theme, and social links with underscores all work as in the original issue #23 so that we can finally close that out (again) - it looks to me like things are working now without detokenize, probably due to the overhaul of social icons by @ShadowMitia last year (thank you again).