### PR TITLE
Correct line spacing with multi-line names and titles

### DIFF
--- a/moderncvheadi.sty
+++ b/moderncvheadi.sty
@@ -43,8 +43,8 @@
 \renewcommand*{\quotefont}{\large\slshape}
 
 % styles
-\renewcommand*{\namestyle}[1]{{\namefont\textcolor{color0}{#1}}}
-\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2}{#1}}}
+\renewcommand*{\namestyle}[1]{{\namefont\textcolor{color0}{#1}\par}}
+\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2}{#1}\par}}
 \renewcommand*{\addressstyle}[1]{{\addressfont\textcolor{color2}{#1}}}
 \renewcommand*{\quotestyle}[1]{{\quotefont\textcolor{color1}{#1}}}
 
@@ -113,7 +113,7 @@
       \if@left\raggedright\fi%
       \if@right\raggedleft\fi%
       \namestyle{\@firstname\ \@lastname}%
-      \ifthenelse{\equal{\@title}{}}{}{\\[1.25em]\titlestyle{\@title}}%
+      \ifthenelse{\equal{\@title}{}}{}{\vspace{1.25em}\titlestyle{\@title}}%
     \end{minipage}}%
   % rendering
   \if@left%

--- a/moderncvheadii.sty
+++ b/moderncvheadii.sty
@@ -48,7 +48,7 @@
 
 % styles
 \renewcommand*{\namestyle}[1]{{\namefont\textcolor{color0}{#1}}}
-\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2}{#1}}}
+\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2}{#1}\par}}
 \renewcommand*{\addressstyle}[1]{{\addressfont\textcolor{color2}{#1}}}
 \renewcommand*{\quotestyle}[1]{{\quotefont\textcolor{color1}{#1}}}
 
@@ -157,7 +157,7 @@
       \titlestyle{\MakeLowercase\@title}%
     \else%
       \titlestyle{\@title}\fi%
-    }\\[2.5em]%
+    }\vspace{2.5ex}%
   % optional quote
   \ifthenelse{\isundefined{\@quote}}%
     {}%

--- a/moderncvheadiii.sty
+++ b/moderncvheadiii.sty
@@ -37,7 +37,7 @@
 
 % styles
 \renewcommand*{\namestyle}[1]{{\namefont\textcolor{color1}{#1}}}
-\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2!85}{#1}}}
+\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2!85}{#1}\par}}
 \renewcommand*{\addressstyle}[1]{{\addressfont\textcolor{color2}{#1}}}
 \renewcommand*{\quotestyle}[1]{{\quotefont\textcolor{color1}{#1}}}
 
@@ -85,7 +85,7 @@
     \ifthenelse{\equal{\@title}{}}{}{\titlestyle{~|~\@title}}% \isundefined doesn't work on \@title, as LaTeX itself defines \@title (before it possibly gets redefined by \title) 
     % optional detailed information
     \if@details{%
-      \\%
+      %\\%
       \addressfont\color{color2}%
       \ifthenelse{\isundefined{\@addressstreet}}{}{\addtomakeheaddetails{\addresssymbol\@addressstreet}%
         \ifthenelse{\equal{\@addresscity}{}}{}{\addtomakeheaddetails[~--~]{\@addresscity}}% if \addresstreet is defined, \addresscity and \addresscountry will always be defined but could be empty

--- a/moderncvheadiv.sty
+++ b/moderncvheadiv.sty
@@ -38,8 +38,8 @@
 \renewcommand*{\quotefont}{\large\itshape}
 
 % styles
-\renewcommand*{\namestyle}[1]{{\namefont\textcolor{color0}{#1}}}
-\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2}{#1}}}
+\renewcommand*{\namestyle}[1]{{\namefont\textcolor{color0}{#1}\par}}
+\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2}{#1}\par}}
 \renewcommand*{\addressstyle}[1]{{\addressfont\textcolor{color2}{#1}}}
 \renewcommand*{\quotestyle}[1]{{\quotefont\textcolor{color1}{#1}}}
 
@@ -92,7 +92,7 @@
     {}%
   \begin{minipage}[b]{\makecvheadnamewidth}%
     \namestyle{\@firstname\ \@lastname}%
-    \ifthenelse{\equal{\@title}{}}{}{\\[1.25em]\titlestyle{\@title}}%
+    \ifthenelse{\equal{\@title}{}}{}{\vspace{1.25em}\titlestyle{\@title}}%
   \end{minipage}%
   % optional photo
   \usebox{\makecvheadpicturebox}\\[2.5em]%

--- a/moderncvheadvi.sty
+++ b/moderncvheadvi.sty
@@ -44,7 +44,7 @@
 
 % styles
 \renewcommand*{\namestyle}[1]{{\namefont\textcolor{color1}{#1}}}
-\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2!85}{#1}}}
+\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2!85}{#1}\par}}
 \renewcommand*{\addressstyle}[1]{{\addressfont\textcolor{color2}{#1}}}
 \renewcommand*{\quotestyle}[1]{{\quotefont\textcolor{color1}{#1}}}
 
@@ -54,7 +54,7 @@
   % name and title
   \if@left\hfill\fi%
   \namestyle{\@firstname~\@lastname}%
-  \ifthenelse{\equal{\@title}{}}{}{\titlestyle{~|~\@title}}\\[-.35em]% \isundefined doesn't work on \@title, as LaTeX itself defines \@title (before it possibly gets redefined by \title)
+  \ifthenelse{\equal{\@title}{}}{}{\titlestyle{~|~\@title}}\vspace{-.35em}% \isundefined doesn't work on \@title, as LaTeX itself defines \@title (before it possibly gets redefined by \title)
   % rule
   {\color{color1}\rule{\textwidth}{.25ex}}}
 


### PR DESCRIPTION
See https://tex.stackexchange.com/q/661729/113546
and https://github.com/xdanaux/moderncv/issues/99

In several head styles the name and title parts are typeset with a specific font (defined in `\namestyle`/`\namefont` and `\titlestyle`/`\titlefont` respectively). This is done inside a group, in braces `{...}`. However the paragraph is not finished inside the group, which means that the element is typeset in the chosen font, but not with the corresponding `\baselineskip`. This manifests itself when a multi-line entry is given where the line spacing is too cramped.

I have corrected this by adding `\par` at the appropriate places. This also causes some `\\` command to have to be replaced by `\vspace`.