### PR TITLE
Avoid conflicts with hyperref includes by other packages

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -103,7 +103,8 @@
 \urlstyle{tt}
 \AtEndPreamble{
   \pagenumbering{arabic}% has to be issued before loading hyperref, as to set \thepage and hence to avoid hyperref issuing a warning and setting pdfpagelabels=false
-  \RequirePackage[unicode]{hyperref}% unicode is required for unicode pdf metadata
+  \PassOptionsToPackage{unicode}{hyperref}
+  \RequirePackage{hyperref}
   \hypersetup{
     breaklinks,
     pdfborder     = 0 0 0,


### PR DESCRIPTION
Pass the `unicode` option through `PassOptionsToPackage` instead of directly specifying it to `RequirePackage`.