### PR TITLE
CI: use thomasweise/docker-texlive-full

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build template
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/moderncv/debian-texlive-docker:main
+      image: thomasweise/docker-texlive-full:latest
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
[thomasWeise/docker-texlive-full](https://github.com/thomasWeise/docker-texlive-full) is much smaller compared to our [moderncv/debian-texlive-docker](https://github.com/moderncv/debian-texlive-docker) since it does some additional cleaning (like removing man pages).