### PR TITLE
Add option to force HTTP to homepage

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -233,8 +233,9 @@
 \newcommand*{\email}[1]{\def\@email{#1}}
 
 % defines one's home page (optional)
-% usage: \homepage{<url>}
-\newcommand*{\homepage}[1]{\def\@homepage{#1}}
+% usage: \homepage[<optional protocol>]{<url>}
+% where <optional protocol> should be either "https" (default) or "http"
+\NewDocumentCommand{\homepage}{O{https}m}{\def\@homepageprotocol{#1}\def\@homepage{#2}}
 
 % adds a fixed/mobile/fax number to one's personal information (optional)
 % usage: \phone[<optional type>]{<number>}

--- a/moderncvfooti.sty
+++ b/moderncvfooti.sty
@@ -89,7 +89,8 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \addtofoot{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
         \ifthenelse{\isundefined{\@email}}{}{\addtofoot{\emailsymbol\emaillink{\@email}}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\addtofoot{\homepagesymbol\httpslink{\@homepage}}}%
+        \ifthenelse{\isundefined{\@homepage}}{}{\addtofoot{\homepagesymbol%
+          \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}}%
         \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
           \addtofoot{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\addtofoot{\@extrainfo}}%
@@ -121,7 +122,8 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \addtofoot{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
         \ifthenelse{\isundefined{\@email}}{}{\addtofoot{\emailsymbol\emaillink{\@email}}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\addtofoot{\homepagesymbol\httpslink{\@homepage}}}%
+        \ifthenelse{\isundefined{\@homepage}}{}{\addtofoot{\homepagesymbol%
+          \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}}%
         \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
           \addtofoot{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\addtofoot{\@extrainfo}}%

--- a/moderncvheadi.sty
+++ b/moderncvheadi.sty
@@ -86,7 +86,8 @@
         \ifthenelse{\isundefined{\@born}}{}{\makenewline\bornsymbol\@born}%
         \phonesdetails% needs to be pre-rendered as loops and tabulars seem to conflict
         \ifthenelse{\isundefined{\@email}}{}{\makenewline\emailsymbol\emaillink{\@email}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol\httpslink{\@homepage}}%
+        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol%
+          \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}%
         \socialsdetails% needs to be pre-rendered as loops and tabulars seem to conflict
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}%
       \end{tabular}
@@ -169,7 +170,8 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \makenewline\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}%
         \ifthenelse{\isundefined{\@email}}{}{\makenewline\emailsymbol\emaillink{\@email}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol\httpslink{\@homepage}}%
+        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol%
+          \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}\fi%
     \end{minipage}\\[2em]
   % recipient block

--- a/moderncvheadii.sty
+++ b/moderncvheadii.sty
@@ -144,7 +144,8 @@
     \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
       \addtomakeheaddetails{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
     \ifthenelse{\isundefined{\@email}}{}{\addtomakeheaddetails{\emailsymbol\emaillink{\@email}}}%
-    \ifthenelse{\isundefined{\@homepage}}{}{\addtomakeheaddetails{\homepagesymbol\httpslink{\@homepage}}}%
+    \ifthenelse{\isundefined{\@homepage}}{}{\addtomakeheaddetails{\homepagesymbol%
+      \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}}%
     \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
       \addtomakeheaddetails{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
     \ifthenelse{\isundefined{\@extrainfo}}{}{\addtomakeheaddetails{\@extrainfo}}%

--- a/moderncvheadiii.sty
+++ b/moderncvheadiii.sty
@@ -95,7 +95,8 @@
       \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
         \addtomakeheaddetails{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
       \ifthenelse{\isundefined{\@email}}{}{\addtomakeheaddetails{\emailsymbol\emaillink{\@email}}}%
-      \ifthenelse{\isundefined{\@homepage}}{}{\addtomakeheaddetails{\homepagesymbol\httpslink{\@homepage}}}%
+      \ifthenelse{\isundefined{\@homepage}}{}{\addtomakeheaddetails{\homepagesymbol%
+        \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}}%
       \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
         \addtomakeheaddetails{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
       \ifthenelse{\isundefined{\@extrainfo}}{}{\addtomakeheaddetails{\@extrainfo}}%
@@ -147,7 +148,8 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \makenewline\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}%
         \ifthenelse{\isundefined{\@email}}{}{\makenewline\emailsymbol\emaillink{\@email}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol\httpslink{\@homepage}}%
+        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol%
+          \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}\fi%
     \end{minipage}\\[2em]
    % recipient block

--- a/moderncvheadiv.sty
+++ b/moderncvheadiv.sty
@@ -111,7 +111,8 @@
       \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
         \makenewline\hbox to 1.0em{\csname\collectionloopkey phonesymbol\endcsname}~\collectionloopitem}%
       \ifthenelse{\isundefined{\@email}}{}{\makenewline\hbox to 1.0em{\emailsymbol}~\emaillink{\@email}}%
-      \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\hbox to 1.0em{\homepagesymbol}~\httpslink{\@homepage}}%
+      \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\hbox to 1.0em{\homepagesymbol}~%
+        \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}%
       \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
         \makenewline\hbox to 1.0em{\csname\collectionloopkey socialsymbol\endcsname}~\collectionloopitem}%
       \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}\fi}
@@ -159,7 +160,8 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \makenewline\hbox to 1.0em{\csname\collectionloopkey phonesymbol\endcsname}~\collectionloopitem}%
         \ifthenelse{\isundefined{\@email}}{}{\makenewline\hbox to 1.0em{\emailsymbol}~\emaillink{\@email}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\hbox to 1.0em{\homepagesymbol}~\httpslink{\@homepage}}%
+        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\hbox to 1.0em{\homepagesymbol}~%
+          \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}%
         \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
           \makenewline\hbox to 1.0em{\csname\collectionloopkey socialsymbol\endcsname}~\collectionloopitem}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}}%

--- a/moderncvheadv.sty
+++ b/moderncvheadv.sty
@@ -83,7 +83,8 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \makenewline\csname\collectionloopkey phonesymbol\endcsname~\collectionloopitem}%
         \ifthenelse{\isundefined{\@email}}{}{\makenewline\emailsymbol~\emaillink{\@email}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol~\httpslink{\@homepage}}%
+        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol~%
+          \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}%
         \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
           \makenewline\csname\collectionloopkey socialsymbol\endcsname~\collectionloopitem}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}\fi}%
@@ -146,7 +147,8 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \makenewline\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}%
         \ifthenelse{\isundefined{\@email}}{}{\makenewline\emailsymbol\emaillink{\@email}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol\httpslink{\@homepage}}%
+        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol%
+          \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}\fi%
     \end{minipage}\\[2em]
   % recipient block

--- a/moderncvheadvi.sty
+++ b/moderncvheadvi.sty
@@ -116,7 +116,8 @@
     \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
       \addtomakeheaddetails{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
     \ifthenelse{\isundefined{\@email}}{}{\addtomakeheaddetails{\emailsymbol\emaillink{\@email}}}%
-    \ifthenelse{\isundefined{\@homepage}}{}{\addtomakeheaddetails{\homepagesymbol\httpslink{\@homepage}}}%
+    \ifthenelse{\isundefined{\@homepage}}{}{\addtomakeheaddetails{\homepagesymbol%
+      \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}}%
     \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
       \addtomakeheaddetails{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
     \ifthenelse{\isundefined{\@extrainfo}}{}{\addtomakeheaddetails{\@extrainfo}}%


### PR DESCRIPTION
This pull request adds an option to force HTTP using homepage, which should close #147. The default value is still HTTPS.

Usage:
`\homepage[http]{www.example.com}` uses HTTP.
`\homepage[https]{www.example.com}` uses HTTPS.
`\homepage{www.example.com}` defaults to HTTPS.
