### PR TITLE
Remove extraneous academicons warning

### DIFF
--- a/moderncviconssymbols.sty
+++ b/moderncviconssymbols.sty
@@ -17,6 +17,7 @@
   \RequirePackage{moderncviconsawesome}
   \RequirePackage{moderncviconsacademic}
 \else
+  \typeout{"moderncv: academicons requires xetex/luatex to work. Using alternatives."}
   \ifpdftex
     \RequirePackage{moderncviconsawesome}
   \else

--- a/moderncviconssymbols.sty
+++ b/moderncviconssymbols.sty
@@ -17,7 +17,7 @@
   \RequirePackage{moderncviconsawesome}
   \RequirePackage{moderncviconsacademic}
 \else
-  \typeout{"moderncv: academicons requires xetex/luatex to work. Using alternatives."}
+  \typeout{^^Jmoderncv: academicons requires XeTeX/LuaTeX to work. Using alternatives.^^J}
   \ifpdftex
     \RequirePackage{moderncviconsawesome}
   \else

--- a/moderncviconssymbols.sty
+++ b/moderncviconssymbols.sty
@@ -17,7 +17,6 @@
   \RequirePackage{moderncviconsawesome}
   \RequirePackage{moderncviconsacademic}
 \else
-  \ClassWarningNoLine{moderncv}{"academicons requires xetex/luatex to work. Using alternatives."}
   \ifpdftex
     \RequirePackage{moderncviconsawesome}
   \else


### PR DESCRIPTION
Fixes #122

Changed [line 20 of `moderncviconssymbols.sty`](https://github.com/moderncv/moderncv/blob/fa3ebb6b482a1e673f3c8377b496eafac17962dc/moderncviconssymbols.sty#L20) from a warning to a log message. Only `moderncviconsacademic.sty` requires the `academicons` package, so a warning is irrelevant to anyone who's not using XeTeX or LuaTeX.