### PR TITLE
Fix `Underfull \hbox (badness 10000)` warning in `\makecvtitle`

### DIFF
--- a/moderncvheadi.sty
+++ b/moderncvheadi.sty
@@ -137,11 +137,17 @@
     \rlap{\usebox{\makecvheaddetailsbox}}% \llap is used to suppress the width of the box, allowing overlap if the value of makecvheadnamewidth is forced
     \hfill%
     \usebox{\makecvheadnamebox}\fi%
-  \\[2.5em]%
   % optional quote
   \ifthenelse{\isundefined{\@quote}}%
-    {}%
-    {{\centering\begin{minipage}{\quotewidth}\centering\quotestyle{\@quote}\end{minipage}\\[2.5em]}}%
+    {\vspace{2.5em}}%
+    {%
+      \\[2.5em]%
+      {%
+        \centering%
+        \begin{minipage}{\quotewidth}%
+          \centering%
+          \quotestyle{\@quote}%
+        \end{minipage}\\[2.5em]}}%
   \par}% to avoid weird spacing bug at the first section if no blank line is left after \makecvhead
 
 

--- a/moderncvheadii.sty
+++ b/moderncvheadii.sty
@@ -158,15 +158,18 @@
       \titlestyle{\MakeLowercase\@title}%
     \else%
       \titlestyle{\@title}\fi%
-    }\\[2.5em]%
+    }
   % optional quote
   \ifthenelse{\isundefined{\@quote}}%
-    {}%
-    {{\null\hfill%
+    {\vspace{2.5em}}%
+    {%
+      \\[2.5em]%
+      {%
+      \centering%
       \begin{minipage}{\quotewidth}%
         \centering%
         \quotestyle{\@quote}%
-      \end{minipage}\hfill\null\\[2.5em]}}%
+      \end{minipage}\\[2.5em]}}%
   \par}% to avoid weird spacing bug at the first section if no blank line is left after \maketitle
 
 

--- a/moderncvheadiii.sty
+++ b/moderncvheadiii.sty
@@ -82,7 +82,7 @@
     \centering%
     % name and title
     \namestyle{\@firstname~\@lastname}%
-    \ifthenelse{\equal{\@title}{}}{}{\titlestyle{~|~\@title}}% \isundefined doesn't work on \@title, as LaTeX itself defines \@title (before it possibly gets redefined by \title) 
+    \ifthenelse{\equal{\@title}{}}{}{\titlestyle{~|~\@title}}% \isundefined doesn't work on \@title, as LaTeX itself defines \@title (before it possibly gets redefined by \title)
     % optional detailed information
     \if@details{%
       \\%
@@ -100,7 +100,7 @@
       \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
         \addtomakeheaddetails{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
       \ifthenelse{\isundefined{\@extrainfo}}{}{\addtomakeheaddetails{\@extrainfo}}%
-      \flushmakeheaddetails}\fi}\\[2.5em]}% need to force a \par after this to avoid weird spacing bug at the first section if no blank line is left after \makehead
+      \flushmakeheaddetails}\fi}}% need to force a \par after this to avoid weird spacing bug at the first section if no blank line is left after \makehead
 
 
 %-------------------------------------------------------------------------------
@@ -118,8 +118,15 @@
   \makehead%
   % optional quote
   \ifthenelse{\isundefined{\@quote}}%
-    {}%
-    {{\centering\begin{minipage}{\quotewidth}\centering\quotestyle{\@quote}\end{minipage}\\[2.5em]}}%
+    {\vspace{2.5em}}%
+    {%
+      \\[2.5em]%
+      {%
+      \centering%
+      \begin{minipage}{\quotewidth}%
+        \centering%
+        \quotestyle{\@quote}%
+      \end{minipage}\\[2.5em]}}%
   \par}% to avoid weird spacing bug at the first section if no blank line is left after \maketitle}
 
 

--- a/moderncvheadv.sty
+++ b/moderncvheadv.sty
@@ -95,14 +95,23 @@
       \namestyle{\@firstname\ \@lastname}%
 	  \ifthenelse{\equal{\@title}{}}{
 	    \ifthenelse{\isundefined{\@quote}}%
-          {}%
-          {\\[1.25em]\begin{minipage}{\quotewidth}\quotestyle{\@quote}\end{minipage}\\[2.5em]}
-	    }{
-	    \\[1.25em]\titlestyle{\@title}\\[2.5em]%
+        {}%
+        {%
+          \\[1.25em]%
+          \begin{minipage}{\quotewidth}%
+            \quotestyle{\@quote}%
+          \end{minipage}}%
+	    }{%
+	      \\[1.25em]%
+        \titlestyle{\@title}
         % optional quote
         \ifthenelse{\isundefined{\@quote}}%
-          {}%
-          {\begin{minipage}{\quotewidth}\quotestyle{\@quote}\end{minipage}\\[2.5em]}}}%
+          {\vspace{2.5em}}%
+          {%
+            \\[2.5em]%
+            \begin{minipage}{\quotewidth}%
+              \quotestyle{\@quote}
+            \end{minipage}}}}%
   \par}% to avoid weird spacing bug at the first section if no blank line is left after \makecvhead
 
 % underlying command to implement \makecvtitle, identical to \@cvitem from moderncvbodyv

--- a/template.tex
+++ b/template.tex
@@ -30,7 +30,7 @@
   \setmainfont{Latin Modern Roman}
   \setsansfont{Latin Modern Sans}
   \setmonofont{Latin Modern Mono}
-  \setmathfont{Latin Modern Math} 
+  \setmathfont{Latin Modern Math}
 \else
   \usepackage[utf8]{inputenc}
   \usepackage[T1]{fontenc}
@@ -161,9 +161,9 @@ Detailed achievements:
 
 \section{Skill matrix}
 \cvitem{Skill matrix}{Alternatively, provide a skill matrix to show off your skills}
-%% Skill matrix as an alternative to rate one's skills, computer or other. 
+%% Skill matrix as an alternative to rate one's skills, computer or other.
 
-%% Adjusts width of skill matrix columns. 
+%% Adjusts width of skill matrix columns.
 %% Usage \setcvskillcolumns[<width>][<factor>][<exp_width>]
 %% <width>, <exp_width> should be lengths smaller than \textwidth, <factor> needs to be between 0 and 1.
 %% Examples:
@@ -202,12 +202,12 @@ Detailed achievements:
 %% Adjust head of the skill matrix for other languages
 % \cvskillhead[0.25em][Level][F\"ahigkeit][Jahre][Bemerkung]
 
-%% \cvskillentry[*][<post_padding>]{<skill_cathegory>}{<0-5>}{<skill_name>}{<years_of_experience>}{<comment>}% 
+%% \cvskillentry[*][<post_padding>]{<skill_cathegory>}{<0-5>}{<skill_name>}{<years_of_experience>}{<comment>}%
 %% Example usages:
 \cvskillentry*{Language:}{3}{Python}{2}{I'm so experienced in Python and have realised a million projects. At least.}
 \cvskillentry{}{2}{Lilypond}{14}{So much sheet music! Man, I'm the best!}
 \cvskillentry{}{3}{\LaTeX}{14}{Clearly I rock at \LaTeX}
-\cvskillentry*{OS:}{3}{Linux}{2}{I only use Archlinux btw}% notice the use of the starred command and the optional 
+\cvskillentry*{OS:}{3}{Linux}{2}{I only use Archlinux btw}% notice the use of the starred command and the optional
 \cvskillentry*[1em]{Methods}{4}{SCRUM}{8}{SCRUM master for 5 years}
 %% \cvskill{<0-5>} command
 % \cvitem{\textbackslash{cvskill}:}{Skills can be visually expressed by the \textbackslash{cvskill} command, e.g. \cvskill{2}}
@@ -279,4 +279,3 @@ Albert Einstein discovered that $e=mc^2$ in 1905.
 
 
 %% end of file `template.tex'.
-


### PR DESCRIPTION
Fixes #108

Fixes vertical spacing before the header quote for the classic, casual, banking, and fancy styles in order to resolve the `Underfull \hbox (badness 10000)` warning in `\makecvtitle`. In these four styles, the quote was set to appear after the additional header info, and some issue in the vertical spacing between these two sections was prompting the warning. See my [comment](https://github.com/moderncv/moderncv/issues/108#issuecomment-1542066475) on the original issue for how I arrived at this solution. Although that comment only delves into my fix for the classic style, the fixes for the other styles were very similar.

I believe this PR should resolve the warning for all styles regardless of whether a quote is defined, but let me know if the warning still appears in some edge case that I missed.