### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -16,20 +16,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build pdf
         run: latexmk -pdflua ./template.tex
 
       - name: Upload pdf
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: template.pdf
           path: ./template.pdf
 
       - name: Upload log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: template.log
           path: ./template.log


### PR DESCRIPTION
Fixes #164

Update `actions/checkout` and `actions/upload-artifact` from v2 to v3. The v2 versions were Node.js 12 actions, which have been depreciated in favor of Node.js 16 actions.