### PR TITLE
Add new `contemporary` style

### DIFF
--- a/commons/colors.tex
+++ b/commons/colors.tex
@@ -15,7 +15,7 @@
 % default colors
 %-------------------------------------------------------------------------------
 
-\colorlet{default-socialicon-color}{darkgrey}
+\@ifundefined{\string\color@default-socialicon-color}{\colorlet{default-socialicon-color}{darkgrey}}{}
 
 %-------------------------------------------------------------------------------
 %                colors for social icons

--- a/moderncvbodyvi.sty
+++ b/moderncvbodyvi.sty
@@ -18,6 +18,10 @@
 %                required packages
 %-------------------------------------------------------------------------------
 \RequirePackage{moderncvverticaltimeline}
+% No customization currently exists for `modercvbodyvi`; just reuse
+% `moderncvbodyi`.  We might consider supporting a short table format (only skill
+% name and rating) in the future.
+\RequirePackage[moderncvbodyi,circle]{moderncvskillmatrix}
 
 
 %-------------------------------------------------------------------------------
@@ -61,6 +65,7 @@
   \setlength{\doubleitemcolumnwidth}{0.5\doubleitemcolumnwidth}%
   \setlength{\listdoubleitemcolumnwidth}{\maincolumnwidth-\listitemsymbolwidth-\separatorcolumnwidth-\listitemsymbolwidth}%
   \setlength{\listdoubleitemcolumnwidth}{0.5\listdoubleitemcolumnwidth}%
+  \recompute@cvskillmatrix@lengths
   % regular lengths
   \setlength{\parskip}{0\p@}}
 

--- a/moderncvbodyvi.sty
+++ b/moderncvbodyvi.sty
@@ -17,13 +17,14 @@
 %-------------------------------------------------------------------------------
 %                required packages
 %-------------------------------------------------------------------------------
+\RequirePackage{moderncvverticaltimeline}
 
 
 %-------------------------------------------------------------------------------
 %                overall body definition
 %-------------------------------------------------------------------------------
 % fonts
-\renewcommand*{\sectionfont}{\Large\mdseries\upshape}
+\renewcommand*{\sectionfont}{\Large\upshape\bfseries}
 \renewcommand*{\subsectionfont}{\large\mdseries\upshape}
 \renewcommand*{\hintfont}{}
 
@@ -66,11 +67,15 @@
 \@initializelength{\baseletterheight}
 \settoheight{\baseletterheight}{\sectionstyle{o}}
 \setlength{\baseletterheight}{\baseletterheight-0.95ex}
-\RenewDocumentCommand{\section}{sm}{%
+% The optional argument can be used to place a small icon near the section name.
+% E.g. `\section[\faBookmark]{Education}`
+\RenewDocumentCommand{\section}{sO{}m}{%
+  \tl@resetchain%
   \par\addvspace{2.5ex}%
   \phantomsection{}% reset the anchor for hyperrefs
-  \addcontentsline{toc}{section}{#2}%
-  \cvitem[0ex]{\strut\raggedleft\raisebox{\baseletterheight}{\color{color1}\rule{\hintscolumnwidth}{0.95ex}}}{\strut\sectionstyle{#2}}%
+  \addcontentsline{toc}{section}{#3}%
+  \strut\sectionstyle{\textcolor{color1!55!white}{{#2}\rule{.75ex}{0pt}\rule{1pt}{\heightof{#3}}}%
+    \rule{.75ex}{0pt}#3}%
   \par\nobreak\addvspace{1ex}\@afterheading}% to avoid a pagebreak after the heading
 
 \RenewDocumentCommand{\subsection}{sm}{%
@@ -105,12 +110,12 @@
     {\listitemsymbol\begin{minipage}[t]{\listdoubleitemcolumnwidth}#3\end{minipage}}}}
 
 \renewcommand*{\cventry}[7][.25em]{%
-  \cvitem[#1]{#2}{%
+  \cvitem[#1]{\tl@milestone{#2}}{%
     {\bfseries#3}%
     \ifthenelse{\equal{#4}{}}{}{, {\slshape#4}}%
     \ifthenelse{\equal{#5}{}}{}{, #5}%
     \ifthenelse{\equal{#6}{}}{}{, #6}%
-    .\strut%
+    \strut%
     \ifx&#7&%
     \else{\newline{}\begin{minipage}[t]{\linewidth}\small#7\end{minipage}}\fi}}
 

--- a/moderncvbodyvi.sty
+++ b/moderncvbodyvi.sty
@@ -165,7 +165,8 @@
   \setlength{\parskip}{6\p@}}
 
 \renewcommand*{\makeletterclosing}{
-  \@closing\\[3em]%
+  \@closing\ifthenelse{\isundefined{\@signature}}{\\[3em]}{\\[1em]}% shrink space when signature is set
+  \ifthenelse{\isundefined{\@signature}}{}{{\@signature\\}}
   {\bfseries\@firstname~\@lastname}%
   \ifthenelse{\isundefined{\@enclosure}}{}{%
     \\%

--- a/moderncvbodyvi.sty
+++ b/moderncvbodyvi.sty
@@ -1,0 +1,175 @@
+%% start of file `moderncvbodyvi.sty'.
+%% Copyright 2006-2015 Xavier Danaux (xdanaux@gmail.com).
+%% Copyright 2023 Javier Lopez-Gomez (javier.lopez.gomez@proton.me).
+%
+% This work may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License version 1.3c,
+% available at http://www.latex-project.org/lppl/.
+
+
+%-------------------------------------------------------------------------------
+%                identification
+%-------------------------------------------------------------------------------
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{moderncvbodyvi}[2023/11/21 v2.0.0 modern curriculum vitae and letter body variant: 6]
+
+
+%-------------------------------------------------------------------------------
+%                required packages
+%-------------------------------------------------------------------------------
+
+
+%-------------------------------------------------------------------------------
+%                overall body definition
+%-------------------------------------------------------------------------------
+% fonts
+\renewcommand*{\sectionfont}{\Large\mdseries\upshape}
+\renewcommand*{\subsectionfont}{\large\mdseries\upshape}
+\renewcommand*{\hintfont}{}
+
+% styles
+\renewcommand*{\sectionstyle}[1]{{\sectionfont\textcolor{color1}{#1}}}
+\renewcommand*{\subsectionstyle}[1]{{\subsectionfont\textcolor{color1}{#1}}}
+\renewcommand*{\hintstyle}[1]{{\hintfont\textcolor{color0}{#1}}}
+
+
+%-------------------------------------------------------------------------------
+%                resume body definition
+%-------------------------------------------------------------------------------
+% lengths
+%   used by \cvitem (and all children command)
+\@initializelength{\hintscolumnwidth}             \setlength{\hintscolumnwidth}{0.175\textwidth}
+\@initializelength{\separatorcolumnwidth}         \setlength{\separatorcolumnwidth}{0.025\textwidth}
+\@initializelength{\maincolumnwidth}
+%   used by \cvdoubleitem
+\@initializelength{\doubleitemcolumnwidth}
+%   used by \cvlistitem
+\@initializelength{\listitemsymbolwidth}          \settowidth{\listitemsymbolwidth}{\listitemsymbol}
+\@initializelength{\listitemcolumnwidth}
+%   used by \cvlistdoubleitem
+\@initializelength{\listdoubleitemcolumnwidth}
+%   default moderncv \photo (change the definition such that by default the photo and its box align with the section bars
+\RenewDocumentCommand{\photo}{O{\hintscolumnwidth-0.8pt-2\fboxsep}O{0.4pt}m}{\def\@photowidth{#1}\def\@photoframewidth{#2}\def\@photo{#3}}%
+
+% commands
+\renewcommand*{\recomputecvbodylengths}{%
+  % body lengths
+  \setlength{\maincolumnwidth}{\textwidth-\leftskip-\rightskip-\separatorcolumnwidth-\hintscolumnwidth}%
+  \setlength{\listitemcolumnwidth}{\maincolumnwidth-\listitemsymbolwidth}%
+  \setlength{\doubleitemcolumnwidth}{\maincolumnwidth-\hintscolumnwidth-\separatorcolumnwidth-\separatorcolumnwidth}%
+  \setlength{\doubleitemcolumnwidth}{0.5\doubleitemcolumnwidth}%
+  \setlength{\listdoubleitemcolumnwidth}{\maincolumnwidth-\listitemsymbolwidth-\separatorcolumnwidth-\listitemsymbolwidth}%
+  \setlength{\listdoubleitemcolumnwidth}{0.5\listdoubleitemcolumnwidth}%
+  % regular lengths
+  \setlength{\parskip}{0\p@}}
+
+\@initializelength{\baseletterheight}
+\settoheight{\baseletterheight}{\sectionstyle{o}}
+\setlength{\baseletterheight}{\baseletterheight-0.95ex}
+\RenewDocumentCommand{\section}{sm}{%
+  \par\addvspace{2.5ex}%
+  \phantomsection{}% reset the anchor for hyperrefs
+  \addcontentsline{toc}{section}{#2}%
+  \cvitem[0ex]{\strut\raggedleft\raisebox{\baseletterheight}{\color{color1}\rule{\hintscolumnwidth}{0.95ex}}}{\strut\sectionstyle{#2}}%
+  \par\nobreak\addvspace{1ex}\@afterheading}% to avoid a pagebreak after the heading
+
+\RenewDocumentCommand{\subsection}{sm}{%
+  \par\addvspace{1ex}%
+  \phantomsection{}% reset the anchor for hyperrefs
+  \addcontentsline{toc}{subsection}{#2}%
+  \cvitem[0ex]{}{\strut\subsectionstyle{#2}}%
+  \par\nobreak\addvspace{.5ex}\@afterheading}% to avoid a pagebreak after the heading
+
+\renewcommand*{\cvitem}[3][.25em]{%
+  \begin{tabular}{@{}p{\hintscolumnwidth}@{\hspace{\separatorcolumnwidth}}p{\maincolumnwidth}@{}}%
+    \raggedleft\hintstyle{#2} &{#3}%
+  \end{tabular}%
+  \par\addvspace{#1}}
+
+\renewcommand*{\cvdoubleitem}[5][.25em]{%
+  \cvitem[#1]{#2}{%
+    \begin{minipage}[t]{\doubleitemcolumnwidth}#3\end{minipage}%
+    \hfill% fill of \separatorcolumnwidth
+    \begin{minipage}[t]{\hintscolumnwidth}\raggedleft\hintstyle{#4}\end{minipage}%
+    \hspace*{\separatorcolumnwidth}%
+    \begin{minipage}[t]{\doubleitemcolumnwidth}#5\end{minipage}}}
+
+\renewcommand*{\cvlistitem}[2][.25em]{%
+  \cvitem[#1]{}{\listitemsymbol\begin{minipage}[t]{\listitemcolumnwidth}#2\end{minipage}}}
+
+\renewcommand*{\cvlistdoubleitem}[3][.25em]{%
+  \cvitem[#1]{}{\listitemsymbol\begin{minipage}[t]{\listdoubleitemcolumnwidth}#2\end{minipage}%
+  \hfill% fill of \separatorcolumnwidth
+  \ifthenelse{\equal{#3}{}}%
+    {}%
+    {\listitemsymbol\begin{minipage}[t]{\listdoubleitemcolumnwidth}#3\end{minipage}}}}
+
+\renewcommand*{\cventry}[7][.25em]{%
+  \cvitem[#1]{#2}{%
+    {\bfseries#3}%
+    \ifthenelse{\equal{#4}{}}{}{, {\slshape#4}}%
+    \ifthenelse{\equal{#5}{}}{}{, #5}%
+    \ifthenelse{\equal{#6}{}}{}{, #6}%
+    .\strut%
+    \ifx&#7&%
+    \else{\newline{}\begin{minipage}[t]{\linewidth}\small#7\end{minipage}}\fi}}
+
+\@initializebox{\cvitemwithcommentbox}
+\@initializelength{\cvitemwithcommentskilllength}
+\@initializelength{\cvitemwithcommentcommentlength}
+\renewcommand*{\cvitemwithcomment}[4][.25em]{%
+  \savebox{\cvitemwithcommentbox}{{#3}}%
+  \setlength{\cvitemwithcommentskilllength}{\widthof{\usebox{\cvitemwithcommentbox}}}%
+  \setlength{\cvitemwithcommentcommentlength}{\maincolumnwidth-\separatorcolumnwidth-\cvitemwithcommentskilllength}%
+  \cvitem[#1]{#2}{%
+    \begin{minipage}[t]{\cvitemwithcommentskilllength}\usebox{\cvitemwithcommentbox}\end{minipage}%
+    \hfill% fill of \separatorcolumnwidth
+    \begin{minipage}[t]{\cvitemwithcommentcommentlength}\raggedleft\small\itshape#4\end{minipage}}}
+
+\renewenvironment{thebibliography}[1]%
+  {%
+    \bibliographyhead{\refname}%
+%    \small%
+    \begin{list}{\bibliographyitemlabel}%
+      {%
+        \setlength{\topsep}{0pt}%
+        \setlength{\labelwidth}{\hintscolumnwidth}%
+        \setlength{\labelsep}{\separatorcolumnwidth}%
+        \leftmargin\labelwidth%
+        \advance\leftmargin\labelsep%
+        \@openbib@code%
+        \usecounter{enumiv}%
+        \let\p@enumiv\@empty%
+        \renewcommand\theenumiv{\@arabic\c@enumiv}}%
+        \sloppy%
+        \clubpenalty4000%\@clubpenalty \clubpenalty%
+        \widowpenalty4000%
+        \sfcode`\.\@m%
+        \sfcode `\=1000\relax}%
+  {%
+    \def\@noitemerr{\@latex@warning{Empty `thebibliography' environment}}%
+    \end{list}}
+
+
+%-------------------------------------------------------------------------------
+%                letter style definition
+%-------------------------------------------------------------------------------
+% commands
+\renewcommand*{\recomputeletterbodylengths}{%
+  \recomputecvlengths%
+  \setlength{\parskip}{6\p@}}
+
+\renewcommand*{\makeletterclosing}{
+  \@closing\\[3em]%
+  {\bfseries\@firstname~\@lastname}%
+  \ifthenelse{\isundefined{\@enclosure}}{}{%
+    \\%
+    \vfil%
+    {\color{color2}\itshape\enclname: \@enclosure}}%
+    \vfil}
+
+
+\endinput
+
+
+%% end of file `moderncvbodyvi.sty'.

--- a/moderncvcolorcerulean.sty
+++ b/moderncvcolorcerulean.sty
@@ -1,0 +1,32 @@
+%% start of file `moderncvcolorcerulean.sty'.
+%% Copyright 2006-2015 Xavier Danaux (xdanaux@gmail.com).
+%% Copyright 2023 Javier Lopez-Gomez (javier.lopez.gomez@proton.me).
+%
+% This work may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License version 1.3c,
+% available at http://www.latex-project.org/lppl/.
+
+
+%-------------------------------------------------------------------------------
+%                identification
+%-------------------------------------------------------------------------------
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{moderncvcolorcerulean}[2023/11/21 v2.0.0 modern curriculum vitae and letter color scheme: cerulean]
+
+
+%-------------------------------------------------------------------------------
+%                color scheme definition
+%-------------------------------------------------------------------------------
+\definecolor{color0}{rgb}{0,0,0}% black
+\definecolor{color1}{HTML}{0081a7}% cerulean
+\definecolor{color2}{HTML}{4d908e}% dark cyan
+\definecolor{headTL}{HTML}{00afb9}% verdigris
+\colorlet{headBR}{color1}
+\definecolor{headtext}{HTML}{ffffff}% white
+\colorlet{headhr}{color2}
+
+
+\endinput
+
+
+%% end of file `moderncvcolorcerulean.sty'.

--- a/moderncvheadvii.sty
+++ b/moderncvheadvii.sty
@@ -120,9 +120,10 @@
         \hspace*{\separatorcolumnwidth}\fi}%
   % optional QR for homepage (pre-rendering)
   \@initializebox{\makecvheadqrbox}%
-  \savebox{\makecvheadqrbox}{%
-    \ifthenelse{\isundefined{\@homepage}}{}{\tikz\node[inner sep=1ex,fill=white]{\qrcode[height=1.5cm]{\@homepage}};}%
-    }%
+  \if@headqr%
+    \savebox{\makecvheadqrbox}{%
+      \ifthenelse{\isundefined{\@homepage}}{}{\tikz\node[inner sep=1ex,fill=white]{\qrcode[height=1.5cm]{\@homepage}};}%
+    }\fi%
   % name and title (pre-rendering)
   \@initializelength{\makecvheaddetailswidth}\settowidth{\makecvheaddetailswidth}{\usebox{\makecvheaddetailsbox}}%
   \@initializelength{\makecvheadpicturewidth}\settowidth{\makecvheadpicturewidth}{\usebox{\makecvheadpicturebox}}%

--- a/moderncvheadvii.sty
+++ b/moderncvheadvii.sty
@@ -17,6 +17,11 @@
 \@initializeif{\if@details}\@detailsfalse
 \DeclareOption{details}   {\@detailstrue}
 \DeclareOption{nodetails} {\@detailsfalse}
+% QR options: "qr" (default) or "noqr".  If "qr" is specified, a QR code is generated to point to the
+% homepage and placed near the details section
+\@initializeif{\if@headqr}\@headqrfalse
+\DeclareOption{qr}   {\@headqrtrue}
+\DeclareOption{noqr} {\@headqrfalse}
 
 % left/right options: "left" (default) or "right"
 \@initializeif{\if@left} \@leftfalse
@@ -25,29 +30,37 @@
 \DeclareOption{right}   {\@leftfalse\@righttrue}
 
 \DeclareOption*{}% avoid choking on unknown options
-\ExecuteOptions{details,left}
+\ExecuteOptions{details,qr,left}
 \ProcessOptions*\relax% \ProcessOptions* processes the options in the order provided (i.e., with the later ones possibly overriding the former ones), while \ProcessOptions processes them in the order of the package
 
 
 %-------------------------------------------------------------------------------
 %                required packages
 %-------------------------------------------------------------------------------
+\RequirePackage{qrcode}
+\RequirePackage{tikz}
+\usetikzlibrary{tikzmark,fit}
 
 
 %-------------------------------------------------------------------------------
 %                overall head definition
 %-------------------------------------------------------------------------------
+\@ifundefined{\string\color@headTL}{\colorlet{headTL}{color1}}{}
+\@ifundefined{\string\color@headBR}{\colorlet{headBR}{color1}}{}
+\@ifundefined{\string\color@headtext}{\colorlet{headtext}{color2}}{}
+\@ifundefined{\string\color@headhr}{\colorlet{headhr}{color2}}{}
+
 % fonts
-\renewcommand*{\namefont}{\fontsize{34}{36}\mdseries\upshape}
+\renewcommand*{\namefont}{\fontsize{30}{32}\rmfamily\mdseries\upshape}
 \renewcommand*{\titlefont}{\LARGE\mdseries\slshape}
 \renewcommand*{\addressfont}{\small\mdseries\slshape}
 \renewcommand*{\quotefont}{\large\slshape}
 
 % styles
-\renewcommand*{\namestyle}[1]{{\namefont\textcolor{color0}{#1}}}
-\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2}{#1}}}
-\renewcommand*{\addressstyle}[1]{{\addressfont\textcolor{color2}{#1}}}
-\renewcommand*{\quotestyle}[1]{{\quotefont\textcolor{color1}{#1}}}
+\renewcommand*{\namestyle}[1]{{\namefont\textcolor{headtext}{#1}}}
+\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{headtext}{#1}}}
+\renewcommand*{\addressstyle}[1]{{\addressfont\textcolor{headtext}{#1}}}
+\renewcommand*{\quotestyle}[1]{{\quotefont\textcolor{color0}{#1}}}
 
 
 %-------------------------------------------------------------------------------
@@ -73,7 +86,7 @@
     \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
       \protected@edef\socialsdetails{\socialsdetails\protect\makenewline\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
     \savebox{\makecvheaddetailsbox}{%
-      \addressfont\color{color2}%
+      \addressfont\color{headtext}%
       \if@left\begin{tabular}[b]{@{}r@{}}\fi%
       \if@right\begin{tabular}[b]{@{}l@{}}\fi%
         \ifthenelse{\isundefined{\@addressstreet}}{}{\makenewline\addresssymbol\@addressstreet%
@@ -92,15 +105,24 @@
     \ifthenelse{\isundefined{\@photo}}%
       {}%
       {%
-        \if@left%
-          \hspace*{\separatorcolumnwidth}\fi%
-        \color{color1}%
-        \setlength{\fboxrule}{\@photoframewidth}%
-        \ifdim\@photoframewidth=0pt%
-          \setlength{\fboxsep}{0pt}\fi%
-        \framebox{\includegraphics[width=\@photowidth]{\@photo}}}%
         \if@right%
-          \hspace*{\separatorcolumnwidth}\fi}%
+          \hspace*{\separatorcolumnwidth}\fi%
+        \begin{tikzpicture}
+          \path[top color=headBR,bottom color=headTL,shading angle=45] (0,0) circle (\dimexpr\@photowidth/2+\@photoframewidth*2);
+          \path[fill=white] (0,0) circle (\dimexpr\@photowidth/2+\@photoframewidth);
+          \begin{scope}
+            \clip (0,0) circle (\dimexpr\@photowidth/2);
+            \node[inner sep=0pt] at (0,0) {\includegraphics[width=\@photowidth]{\@photo}};
+          \end{scope}
+        \end{tikzpicture}%
+      }%
+      \if@left%
+        \hspace*{\separatorcolumnwidth}\fi}%
+  % optional QR for homepage (pre-rendering)
+  \@initializebox{\makecvheadqrbox}%
+  \savebox{\makecvheadqrbox}{%
+    \ifthenelse{\isundefined{\@homepage}}{}{\tikz\node[inner sep=1ex,fill=white]{\qrcode[height=1.5cm]{\@homepage}};}%
+    }%
   % name and title (pre-rendering)
   \@initializelength{\makecvheaddetailswidth}\settowidth{\makecvheaddetailswidth}{\usebox{\makecvheaddetailsbox}}%
   \@initializelength{\makecvheadpicturewidth}\settowidth{\makecvheadpicturewidth}{\usebox{\makecvheadpicturebox}}%
@@ -112,25 +134,39 @@
     \begin{minipage}[b]{\makecvheadnamewidth}%
       \if@left\raggedright\fi%
       \if@right\raggedleft\fi%
-      \namestyle{\@firstname\ \@lastname}%
+      \namestyle{\@firstname\ {\scshape\@lastname}}%
       \ifthenelse{\equal{\@title}{}}{}{\\[1.25em]\titlestyle{\@title}}%
     \end{minipage}}%
   % rendering
+  \begin{tikzpicture}[remember picture,overlay]
+    \node(head-bg) [top color=headTL,bottom color=headBR,shading angle=45,inner sep=0pt,
+      fit={(current page.north west)(current page.north east)(pic cs:head-end)}] {};
+    % Users may define `\@moderncvheadBackground` for additional background decoration
+    \ifthenelse{\isundefined{\@moderncvheadBackground}}{}{\@moderncvheadBackground}
+
+    \path[draw,line width=\@photoframewidth]
+        (head-bg.south west) edge[color=headhr!85!black] ([xshift=8em]head-bg.south west)
+        ([xshift=8em]head-bg.south west) edge[color=headhr] ([xshift=-8em]head-bg.south east)
+        ([xshift=-8em]head-bg.south east) edge[color=headhr!85!black] (head-bg.south east);
+  \end{tikzpicture}%
   \if@left%
+    \usebox{\makecvheadpicturebox}%
     \usebox{\makecvheadnamebox}%
     \hfill%
     \llap{\usebox{\makecvheaddetailsbox}}% \llap is used to suppress the width of the box, allowing overlap if the value of makecvheadnamewidth is forced
-    \usebox{\makecvheadpicturebox}\fi%
+    \usebox{\makecvheadqrbox}\fi%
   \if@right%
-    \usebox{\makecvheadpicturebox}%
+    \usebox{\makecvheadqrbox}%
     \rlap{\usebox{\makecvheaddetailsbox}}% \llap is used to suppress the width of the box, allowing overlap if the value of makecvheadnamewidth is forced
     \hfill%
-    \usebox{\makecvheadnamebox}\fi%
-  \\[2.5em]%
+    \usebox{\makecvheadnamebox}%
+    \usebox{\makecvheadpicturebox}\fi%
+  \\[.15em]%
+  \tikzmark{head-end}\\[.15em]%
   % optional quote
   \ifthenelse{\isundefined{\@quote}}%
     {}%
-    {{\centering\begin{minipage}{\quotewidth}\centering\quotestyle{\@quote}\end{minipage}\\[2.5em]}}%
+    {{\centering\begin{minipage}{\quotewidth}\centering\quotestyle{\@quote}\end{minipage}\\[.15em]}}%
   \par}% to avoid weird spacing bug at the first section if no blank line is left after \makecvhead
 
 

--- a/moderncvheadvii.sty
+++ b/moderncvheadvii.sty
@@ -1,0 +1,187 @@
+%% start of file `moderncvheadvii.sty'.
+%% Copyright 2006-2015 Xavier Danaux (xdanaux@gmail.com).
+%% Copyright 2023 Javier Lopez-Gomez (javier.lopez.gomez@proton.me).
+%
+% This work may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License version 1.3c,
+% available at http://www.latex-project.org/lppl/.
+
+
+%-------------------------------------------------------------------------------
+%                identification
+%-------------------------------------------------------------------------------
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{moderncvheadvii}[2023/11/21 v2.0.0 modern curriculum vitae and letter header variant: 7]
+
+% details options: "details" (default) or "nodetails"
+\@initializeif{\if@details}\@detailsfalse
+\DeclareOption{details}   {\@detailstrue}
+\DeclareOption{nodetails} {\@detailsfalse}
+
+% left/right options: "left" (default) or "right"
+\@initializeif{\if@left} \@leftfalse
+\DeclareOption{left}    {\@lefttrue\@rightfalse}
+\@initializeif{\if@right}\@rightfalse
+\DeclareOption{right}   {\@leftfalse\@righttrue}
+
+\DeclareOption*{}% avoid choking on unknown options
+\ExecuteOptions{details,left}
+\ProcessOptions*\relax% \ProcessOptions* processes the options in the order provided (i.e., with the later ones possibly overriding the former ones), while \ProcessOptions processes them in the order of the package
+
+
+%-------------------------------------------------------------------------------
+%                required packages
+%-------------------------------------------------------------------------------
+
+
+%-------------------------------------------------------------------------------
+%                overall head definition
+%-------------------------------------------------------------------------------
+% fonts
+\renewcommand*{\namefont}{\fontsize{34}{36}\mdseries\upshape}
+\renewcommand*{\titlefont}{\LARGE\mdseries\slshape}
+\renewcommand*{\addressfont}{\small\mdseries\slshape}
+\renewcommand*{\quotefont}{\large\slshape}
+
+% styles
+\renewcommand*{\namestyle}[1]{{\namefont\textcolor{color0}{#1}}}
+\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2}{#1}}}
+\renewcommand*{\addressstyle}[1]{{\addressfont\textcolor{color2}{#1}}}
+\renewcommand*{\quotestyle}[1]{{\quotefont\textcolor{color1}{#1}}}
+
+
+%-------------------------------------------------------------------------------
+%                resume head definition
+%-------------------------------------------------------------------------------
+% lengths
+\@initializelength{\quotewidth}
+\@initializelength{\makecvheadnamewidth}% optional makecvheadname width to force a certain width (if set/remains to 0pt, the width is calculated automatically)
+\renewcommand*{\recomputecvheadlengths}{%
+  \setlength{\quotewidth}{0.65\textwidth}}
+
+% commands
+\renewcommand*{\makecvhead}{%
+  % recompute lengths (in case we are switching from letter to resume, or vice versa)
+  \recomputecvlengths%
+  % optional detailed information (pre-rendering)
+  \@initializebox{\makecvheaddetailsbox}%
+  \if@details%
+    \def\phonesdetails{}%
+    \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
+      \protected@edef\phonesdetails{\phonesdetails\protect\makenewline\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
+    \def\socialsdetails{}%
+    \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
+      \protected@edef\socialsdetails{\socialsdetails\protect\makenewline\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
+    \savebox{\makecvheaddetailsbox}{%
+      \addressfont\color{color2}%
+      \if@left\begin{tabular}[b]{@{}r@{}}\fi%
+      \if@right\begin{tabular}[b]{@{}l@{}}\fi%
+        \ifthenelse{\isundefined{\@addressstreet}}{}{\makenewline\addresssymbol\@addressstreet%
+          \ifthenelse{\equal{\@addresscity}{}}{}{\makenewline\@addresscity}% if \addresstreet is defined, \addresscity and addresscountry will always be defined but could be empty
+          \ifthenelse{\equal{\@addresscountry}{}}{}{\makenewline\@addresscountry}}%
+        \phonesdetails% needs to be pre-rendered as loops and tabulars seem to conflict
+        \ifthenelse{\isundefined{\@email}}{}{\makenewline\emailsymbol\emaillink{\@email}}%
+        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol\httplink{\@homepage}}%
+        \socialsdetails% needs to be pre-rendered as loops and tabulars seem to conflict
+        \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}%
+      \end{tabular}
+    }\fi%
+  % optional photo (pre-rendering)
+  \@initializebox{\makecvheadpicturebox}%
+  \savebox{\makecvheadpicturebox}{%
+    \ifthenelse{\isundefined{\@photo}}%
+      {}%
+      {%
+        \if@left%
+          \hspace*{\separatorcolumnwidth}\fi%
+        \color{color1}%
+        \setlength{\fboxrule}{\@photoframewidth}%
+        \ifdim\@photoframewidth=0pt%
+          \setlength{\fboxsep}{0pt}\fi%
+        \framebox{\includegraphics[width=\@photowidth]{\@photo}}}%
+        \if@right%
+          \hspace*{\separatorcolumnwidth}\fi}%
+  % name and title (pre-rendering)
+  \@initializelength{\makecvheaddetailswidth}\settowidth{\makecvheaddetailswidth}{\usebox{\makecvheaddetailsbox}}%
+  \@initializelength{\makecvheadpicturewidth}\settowidth{\makecvheadpicturewidth}{\usebox{\makecvheadpicturebox}}%
+  \ifthenelse{\lengthtest{\makecvheadnamewidth=0pt}}% check for dummy value (equivalent to \ifdim\makecvheadnamewidth=0pt)
+    {\setlength{\makecvheadnamewidth}{\textwidth-\makecvheaddetailswidth-\makecvheadpicturewidth}}%
+    {}%
+  \@initializebox{\makecvheadnamebox}%
+  \savebox{\makecvheadnamebox}{%
+    \begin{minipage}[b]{\makecvheadnamewidth}%
+      \if@left\raggedright\fi%
+      \if@right\raggedleft\fi%
+      \namestyle{\@firstname\ \@lastname}%
+      \ifthenelse{\equal{\@title}{}}{}{\\[1.25em]\titlestyle{\@title}}%
+    \end{minipage}}%
+  % rendering
+  \if@left%
+    \usebox{\makecvheadnamebox}%
+    \hfill%
+    \llap{\usebox{\makecvheaddetailsbox}}% \llap is used to suppress the width of the box, allowing overlap if the value of makecvheadnamewidth is forced
+    \usebox{\makecvheadpicturebox}\fi%
+  \if@right%
+    \usebox{\makecvheadpicturebox}%
+    \rlap{\usebox{\makecvheaddetailsbox}}% \llap is used to suppress the width of the box, allowing overlap if the value of makecvheadnamewidth is forced
+    \hfill%
+    \usebox{\makecvheadnamebox}\fi%
+  \\[2.5em]%
+  % optional quote
+  \ifthenelse{\isundefined{\@quote}}%
+    {}%
+    {{\centering\begin{minipage}{\quotewidth}\centering\quotestyle{\@quote}\end{minipage}\\[2.5em]}}%
+  \par}% to avoid weird spacing bug at the first section if no blank line is left after \makecvhead
+
+
+%-------------------------------------------------------------------------------
+%                letter head definition
+%-------------------------------------------------------------------------------
+% lengths
+%\renewcommand*{\recomputeletterheadlengths}{}
+
+% commands
+\renewcommand*{\makeletterhead}{%
+  % recompute lengths (in case we are switching from letter to resume, or vice versa)
+  \recomputeletterlengths%
+  % sender contact info
+  \hfill%
+  \begin{minipage}{.5\textwidth}%
+    % optional detailed information
+    \if@details%
+      \raggedleft%
+      \addressfont\textcolor{color2}{%
+        {\bfseries\upshape\@firstname~\@lastname}\@firstdetailselementfalse%
+        % optional detailed information
+        \ifthenelse{\isundefined{\@addressstreet}}{}{\makenewline\addresssymbol\@addressstreet%
+          \ifthenelse{\equal{\@addresscity}{}}{}{\makenewline\@addresscity}% if \addresstreet is defined, \addresscity and addresscountry will always be defined but could be empty
+          \ifthenelse{\equal{\@addresscountry}{}}{}{\makenewline\@addresscountry}}%
+        \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
+          \makenewline\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}%
+        \ifthenelse{\isundefined{\@email}}{}{\makenewline\emailsymbol\emaillink{\@email}}%
+        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol\httplink{\@homepage}}%
+        \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}\fi%
+    \end{minipage}\\[1em]
+  % recipient block
+  \begin{minipage}[t]{.5\textwidth}
+    \raggedright%
+    \addressfont%
+    {\bfseries\upshape\@recipientname}\\%
+    \@recipientaddress%
+  \end{minipage}
+  % date
+  \hfill% US style
+%  \\[1em]% UK style
+  \@date\\[2em]% US informal style: "January 1, 1900"; UK formal style: "01/01/1900"
+  % opening
+  \raggedright%
+  \@opening\\[1.5em]%
+  % ensure no extra spacing after \makelettertitle due to a possible blank line
+%  \ignorespacesafterend% not working
+  \hspace{0pt}\par\vspace{-\baselineskip}\vspace{-\parskip}}
+
+
+\endinput
+
+
+%% end of file `moderncvheadvii.sty'.

--- a/moderncvheadvii.sty
+++ b/moderncvheadvii.sty
@@ -209,6 +209,8 @@
   \hfill% US style
 %  \\[1em]% UK style
   \@date\\[2em]% US informal style: "January 1, 1900"; UK formal style: "01/01/1900"
+  % optional subject
+  \ifthenelse{\isundefined{\@subject}}{}{{\bfseries\@subject\\[3em]}}
   % opening
   \raggedright%
   \@opening\\[1.5em]%

--- a/moderncvskillmatrix.sty
+++ b/moderncvskillmatrix.sty
@@ -218,6 +218,10 @@
 \@initializeif{\if@moderncvbodyv}\@moderncvbodyvfalse
 \DeclareOption{moderncvbodyv}{\@moderncvbodyifalse\@moderncvbodyiifalse\@moderncvbodyiiifalse\@moderncvbodyivfalse\@moderncvbodyvtrue}
 
+% If option `circle` is specified, use circles instead of small rectangles for rating skills
+\@initializeif{\if@cvskillcircle}\@cvskillcirclefalse
+\DeclareOption{circle}{\@cvskillcircletrue}
+
 \DeclareOption*{}% avoid choking on unknown options
 \ExecuteOptions{moderncvbodyi}
 \ProcessOptions*\relax% \ProcessOptions* processes the options in the order provided (i.e., with the later ones possibly overriding the former ones), while \ProcessOptions processes them in the order of the package
@@ -239,8 +243,14 @@
 % %-------------------------------------------------------------------------------
 % The code for the Skilllevel illustration with the little boxes.
 % This is idea stolen from the limecv package, see https://github.com/opieters/limecv.git
-\@initializelength{\cvSkill@RectangleSize}
-\setlength{\cvSkill@RectangleSize}{1.2ex}
+\@initializelength{\cvSkill@ShapeSize}
+\if@cvskillcircle%
+    \setlength{\cvSkill@ShapeSize}{.7ex}%
+    \def\cvSkill@Shape#1{\tikz\filldraw[#1] (0, 0) circle (\cvSkill@ShapeSize);}
+\else
+    \setlength{\cvSkill@ShapeSize}{1.2ex}
+    \def\cvSkill@Shape#1{\tikz\filldraw[#1] (0, 0) rectangle (\cvSkill@ShapeSize, \cvSkill@ShapeSize);}
+\fi
 \newcount\my@repeat@count
 \DeclareDocumentCommand{\cvskill}{m}{%
 %   Illustrate skill level with little colored boxes.
@@ -252,10 +262,10 @@
 %       \cvskill{3}
     \begingroup
         \my@repeat@count=\z@
-        \@whilenum\my@repeat@count<#1\do{\tikz\filldraw[skillmatrixfullcolor] (0, 0) rectangle (\cvSkill@RectangleSize, \cvSkill@RectangleSize);\advance%
+        \@whilenum\my@repeat@count<#1\do{\cvSkill@Shape{skillmatrixfullcolor}\advance%
         \my@repeat@count\@ne\,}%
         \my@repeat@count=\numexpr5-\z@\relax
-        \@whilenum\my@repeat@count>#1\do{\tikz\filldraw[skillmatrixemptycolor] (0, 0) rectangle (\cvSkill@RectangleSize, \cvSkill@RectangleSize);\advance%
+        \@whilenum\my@repeat@count>#1\do{\cvSkill@Shape{skillmatrixemptycolor}\advance%
         \my@repeat@count\m@ne\,}%
     \endgroup
 }% end \cvskill

--- a/moderncvstylecontemporary.sty
+++ b/moderncvstylecontemporary.sty
@@ -39,7 +39,8 @@
 %\fi
 
 % symbols
-\moderncvicons{marvosym}
+\providecolor{default-socialicon-color}{named}{headtext}
+\moderncvicons{symbols}
 
 %-------------------------------------------------------------------------------
 %               Colors

--- a/moderncvstylecontemporary.sty
+++ b/moderncvstylecontemporary.sty
@@ -1,0 +1,53 @@
+%% start of file `moderncvstylecontemporary.sty'.
+%% Copyright 2006-2015 Xavier Danaux (xdanaux@gmail.com).
+%% Copyright 2023 Javier Lopez-Gomez (javier.lopez.gomez@proton.me).
+%
+% This work may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License version 1.3c,
+% available at http://www.latex-project.org/lppl/.
+
+
+%-------------------------------------------------------------------------------
+%                identification
+%-------------------------------------------------------------------------------
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{moderncvstylecontemporary}[2023/11/24 v2.0.0 modern curriculum vitae and letter style scheme: contemporary]
+
+% head section alignment options: "left" (default) or "right"
+\@initializecommand{\moderncvstyleheadoptions}{}
+\DeclareOption{left} {\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,left}}
+\DeclareOption{right}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,right}}
+
+\DeclareOption*{}% avoid choking on unknown options
+\ExecuteOptions{left}
+\ProcessOptions*\relax% \ProcessOptions* processes the options in the order provided (i.e., with the later ones possibly overriding the former ones), while \ProcessOptions processes them in the order of the package
+
+%-------------------------------------------------------------------------------
+%                fonts & icons
+%-------------------------------------------------------------------------------
+% Latin Modern fonts
+%\ifxetexorluatex
+%  \setmainfont{Latin Modern Roman}
+%  \setsansfont{Latin Modern Sans}
+%  \setmathfont{Latin Modern Math}
+%\else
+  \IfFileExists{lmodern.sty}%
+    {\RequirePackage{lmodern}}%
+    {}
+%\fi
+
+% symbols
+\moderncvicons{marvosym}
+
+
+%-------------------------------------------------------------------------------
+%                header, body & footer
+%-------------------------------------------------------------------------------
+\moderncvhead[\moderncvstyleheadoptions]{7}
+\moderncvbody{6}
+
+
+\endinput
+
+
+%% end of file `moderncvstylecontemporary.sty'.

--- a/moderncvstylecontemporary.sty
+++ b/moderncvstylecontemporary.sty
@@ -17,9 +17,11 @@
 \@initializecommand{\moderncvstyleheadoptions}{}
 \DeclareOption{left} {\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,left}}
 \DeclareOption{right}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,right}}
+\DeclareOption{qr}  {\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,qr}}
+\DeclareOption{noqr}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,noqr}}
 
 \DeclareOption*{}% avoid choking on unknown options
-\ExecuteOptions{left}
+\ExecuteOptions{left,qr}
 \ProcessOptions*\relax% \ProcessOptions* processes the options in the order provided (i.e., with the later ones possibly overriding the former ones), while \ProcessOptions processes them in the order of the package
 
 %-------------------------------------------------------------------------------

--- a/moderncvstylecontemporary.sty
+++ b/moderncvstylecontemporary.sty
@@ -41,6 +41,13 @@
 % symbols
 \moderncvicons{marvosym}
 
+%-------------------------------------------------------------------------------
+%               Colors
+%-------------------------------------------------------------------------------
+% skillmatrix
+\colorlet{bodyrulecolor}{color1}
+\colorlet{skillmatrixfullcolor}{color1}
+\colorlet{skillmatrixemptycolor}{color2!30}
 
 %-------------------------------------------------------------------------------
 %                header, body & footer

--- a/moderncvverticaltimeline.sty
+++ b/moderncvverticaltimeline.sty
@@ -1,0 +1,79 @@
+%% start of file `moderncvverticaltimeline.sty'.
+%% Copyright 2023 Javier Lopez-Gomez (javier.lopez.gomez@proton.me).
+%
+% This work may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License version 1.3c,
+% available at http://www.latex-project.org/lppl/.
+
+
+%-------------------------------------------------------------------------------
+%                identification
+%-------------------------------------------------------------------------------
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{moderncvverticaltimeline}[2023/11/29 v2.0.0 modern curriculum vitae vertical timeline]
+
+
+%-------------------------------------------------------------------------------
+%                required packages
+%-------------------------------------------------------------------------------
+\RequirePackage{tikz}
+
+%-------------------------------------------------------------------------------
+%                vertical timeline implementation
+%-------------------------------------------------------------------------------
+\tikzset{
+  tl_milestone/.style={circle,inner sep=1.5pt,draw=color0!20,label={west:#1}},
+  tl_link/.style={thick,densely dotted,color0!20},
+}
+
+\newcounter{tl@chainidx}\setcounter{tl@chainidx}{0}
+\newcounter{tl@nodeidx}\setcounter{tl@nodeidx}{0}
+
+% Mark the end of the current chain; any `\tl@milestone` issued afterward will be on a new timeline.
+\def\tl@resetchain{%
+  \stepcounter{tl@chainidx}%
+  \setcounter{tl@nodeidx}{0}%
+}
+
+% Create a node in the current timeline and link it to the previous node; if the previous milestone
+% is on the last shipped out page, draw a line that extends until the top margin.  The argument is laid out as a label (default left).
+\def\tl@milestone#1{%
+  \edef\@tl@prev{tl-\thetl@chainidx-\thetl@nodeidx}%
+  \stepcounter{tl@nodeidx}%
+  \edef\@tl@this{tl-\thetl@chainidx-\thetl@nodeidx}%
+  \tikz[remember picture,overlay] {
+    \node[tl_milestone={#1}] (\@tl@this) {};
+    \ifnum\thetl@nodeidx>1
+      \pgfpointdiff{\pgfpointanchor{\@tl@prev}{center}}{\pgfpointanchor{\@tl@this}{center}}
+      \ifnum\pgf@y>0
+        \draw[tl_link] (\@tl@this) -- ([yshift=-1em] \@tl@this |- current page.north);
+      \else
+        \draw[tl_link] (\@tl@this) -- (\@tl@prev);
+      \fi
+    \fi
+  }
+}
+
+\AddToHook{shipout/background}{%
+  % If there are follow-up  milestones in the current timeline, draw a line that extends until the bottom margin
+  \edef\@tl@prev{tl-\thetl@chainidx-\number\numexpr\thetl@nodeidx-1}%
+  \edef\@tl@this{tl-\thetl@chainidx-\thetl@nodeidx}%
+  \tikz[remember picture,overlay] {
+    \ifnum\thetl@nodeidx>1
+      \pgfpointdiff{\pgfpointanchor{\@tl@prev}{center}}{\pgfpointanchor{\@tl@this}{center}}
+      \ifnum\pgf@y>0
+        \draw[tl_link] (\@tl@prev) -- ([yshift=1em] \@tl@prev |- current page.south);
+      \fi
+    \fi
+  }
+}
+
+\AtEndDocument{\tl@resetchain}
+
+\let\@old@section=\section%
+\RenewDocumentCommand{\section}{sm}{\tl@resetchain\@old@section{#1}}
+
+\endinput
+
+
+%% end of file `moderncvverticaltimeline.sty'.

--- a/template.tex
+++ b/template.tex
@@ -8,16 +8,22 @@
 
 \documentclass[11pt,a4paper,sans]{moderncv}        % possible options include font size ('10pt', '11pt' and '12pt'), paper size ('a4paper', 'letterpaper', 'a5paper', 'legalpaper', 'executivepaper' and 'landscape') and font family ('sans' and 'roman')
 
-\moderncvcolor{blue}                               % color options 'black', 'blue' (default), 'burgundy', 'green', 'grey', 'orange', 'purple' and 'red'
+\moderncvcolor{cerulean}                           % color options 'black', 'blue' (default), 'burgundy', 'green', 'grey', 'orange', 'purple' and 'red'; for contemporary style use 'cerulean'
 % moderncv themes
-\moderncvstyle{casual}                             % style options are 'casual' (default), 'classic', 'banking', 'oldstyle' and 'fancy'
+\moderncvstyle[]{contemporary}                     % style options are 'casual' (default), 'classic', 'banking', 'oldstyle', 'fancy' and 'contemporary'
+                                                   % the 'contemporary' style optionally takes the `qr` (default) or `noqr` options
 %\renewcommand{\familydefault}{\sfdefault}         % to set the default font; use '\sfdefault' for the default sans serif font, '\rmdefault' for the default roman one, or any tex font name
 %\nopagenumbers{}                                  % uncomment to suppress automatic page numbering for CVs longer than one page
 
 % adjust the page margins
-\usepackage[scale=0.75]{geometry}
+\usepackage[hmargin=0.5in,vmargin=10pt]{geometry}                  % the 'contemporary' style looks better with reduced margins; uncomment the line below for increased margin
+%\usepackage[scale=0.75]{geometry}
 %\setlength{\hintscolumnwidth}{3cm}                % if you want to change the width of the column with the dates
 %\setlength{\makecvheadnamewidth}{10cm}            % for the 'classic' style, if you want to force the width allocated to your name and avoid line breaks. be careful though, the length is normally calculated to avoid any overlap with your personal info; use this at your own typographical risks...
+
+% the 'contemporary' style allows to append additional elements to the head background; uncomment and customize if needed
+%\def\@moderncvheadBackground{
+%}
 
 % font loading
 % for luatex and xetex, do not use inputenc and fontenc
@@ -30,6 +36,12 @@
   \setsansfont{Latin Modern Sans}
   \setmonofont{Latin Modern Mono}
   \setmathfont{Latin Modern Math}
+
+  % you may also consider Fira Sans Light for a extra modern look
+  %\setsansfont[ItalicFont={Fira Sans Light Italic},%
+  %           BoldFont={Fira Sans},%
+  %           BoldItalicFont={Fira Sans Italic}]%
+  %           {Fira Sans Light}%
 \else
   \usepackage[utf8]{inputenc}
   \usepackage[T1]{fontenc}
@@ -95,7 +107,7 @@
 
 
 \extrainfo{additional information}                 % optional, remove / comment the line if not wanted
-\photo[64pt][0.4pt]{picture}                       % optional, remove / comment the line if not wanted; '64pt' is the height the picture must be resized to, 0.4pt is the thickness of the frame around it (put it to 0pt for no frame) and 'picture' is the name of the picture file
+\photo[64pt][2pt]{picture}                       % optional, remove / comment the line if not wanted; '64pt' is the height the picture must be resized to, 2pt is the thickness of the frame around it (put it to 0pt for no frame) and 'picture' is the name of the picture file
 \quote{Some quote}                                 % optional, remove / comment the line if not wanted
 
 % bibliography adjustments (only useful if you make citations in your resume, or print a list of publications using BibTeX)
@@ -116,7 +128,7 @@
 %-----       resume       ---------------------------------------------------------
 \makecvtitle
 
-\section{Education}
+\section{Education}  % for 'contemporary' style use optional argument for displaying an icon, e.g. \section[\faGraduationCap]{Education}
 \cventry{year--year}{Degree}{Institution}{City}{\textit{Grade}}{Description}  % arguments 3 to 6 can be left empty
 \cventry{year--year}{Degree}{Institution}{City}{\textit{Grade}}{Description}
 


### PR DESCRIPTION
This pull request introduces the new `contemporary` theme, largely based on `classic`, yet looking more up-to-date (see below for a screenshot).  `contemporary` features a nice-looking header, incl. a QR-code pointing to `\@homepage`, vertical timelines that span over a section, and the possibility to add symbols (e.g. using `fontawesome5`) to the section names.

@xdanaux, @moderncv, Please review, and let me know whether changes / fixes are needed before merging.

### Changes
- Add `moderncvverticaltimeline.sty`, implementing typesetting of a vertical timeline using PGF/TikZ.
- Add a new color theme, cerulean, made specifically for the contemporary style.
- Add style `moderncvstylecontemporary.sty`, together with new head and body styles.

![contemporary-10pt](https://github.com/xdanaux/moderncv/assets/36541918/81f34c88-59db-4fca-b4ac-9939ddb31eb5)