### PR TITLE
Replace \weblink with \link in user guide

### DIFF
--- a/manual/moderncv_userguide.tex
+++ b/manual/moderncv_userguide.tex
@@ -179,7 +179,7 @@ In practice, you will type:
 \phone{+12 (3)456 78 90}
 \fax{+12 (3)456 78 90}
 \email{jdoe@design.org}
-\extrainfo{\weblink{www.ctan.org}}
+\extrainfo{\link{www.ctan.org}}
 \photo[64pt]{jdoe_picture}
 \quote{Any intelligent fool can make things bigger, more complex,
 and more violent. It takes a touch of genius -- and a lot of courage -- to
@@ -442,7 +442,7 @@ In particular, the first column can be set to any width. You can do that in two 
 \subsection*{Additional commands}
 There are commands to manage hypertextual links:
 \begin{itemize}
- \item[-] \verb|\weblink[optional text]{link}|
+ \item[-] \verb|\link[optional text]{link}|
  \item[-] \verb|\httplink[optional text]{link}|
  \item[-] \verb|\emaillink[optional text]{link}|
 \end{itemize}


### PR DESCRIPTION
As pointed out in #79, the documented command `\weblink` is actually implemented as `\link` (see also
https://github.com/moderncv/moderncv/blob/f3dd14ff621583bb6ce12d7e84a499f54cfa068f/moderncv.cls#L572). This change thus fixes the docs and reduces confusion for users who copy this code from the documented example in the manual.

This pull request is submitted in the hope that it is useful. If you wish for anything to be changed, please just let me know and I'll update the code as required and resubmit.