### PR TITLE
Use page number font when setting page number width

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -145,7 +145,7 @@
       \@ifundefined{r@lastpage}{}{%
         \ifthenelse{\pageref{lastpage}>1}{%
           \newlength{\pagenumberwidth}%
-          \settowidth{\pagenumberwidth}{\color{color2}\addressfont\itshape\strut\thepage/\pageref{lastpage}}%
+          \settowidth{\pagenumberwidth}{\color{color2}\pagenumberfont\strut\thepage/\pageref{lastpage}}%
           \fancypagestyle{plain}{%
             \fancyfoot[r]{\parbox[b]{\pagenumberwidth}{\color{color2}\pagenumberfont\strut\thepage/\protect\NoHyper\pageref{lastpage}\protect\endNoHyper}}}% the parbox is required to ensure alignment with a possible center footer (e.g., as in the casual style)
           \pagestyle{plain}}{}}\fi}%


### PR DESCRIPTION
When the `\pagenumberfont` is changed, e.g., to remove italics, the page number width is still calculated using the default `\addressfont\itshape` definition.