### PR TITLE
Restore previous cvlistitem spacing

### DIFF
--- a/moderncvbodyi.sty
+++ b/moderncvbodyi.sty
@@ -49,7 +49,7 @@
 \@initializelength{\listitemcolumnwidth}
 %   used by \cvlistdoubleitem
 \@initializelength{\listdoubleitemcolumnwidth}
-\@initializelength{\listitemsymbolspace}          \settowidth{\listitemsymbolspace}{0pt}
+\@initializelength{\listitemsymbolspace}          \setlength{\listitemsymbolspace}{0pt}
 %   default moderncv \photo (change the definition such that by default the photo and its box align with the section bars
 \RenewDocumentCommand{\photo}{O{\hintscolumnwidth-0.8pt-2\fboxsep}O{0.4pt}m}{\def\@photowidth{#1}\def\@photoframewidth{#2}\def\@photo{#3}}%
 

--- a/moderncvbodyiii.sty
+++ b/moderncvbodyiii.sty
@@ -88,7 +88,7 @@
 \@initializelength{\listitemcolumnwidth}
 %   used by \cvlistdoubleitem
 \@initializelength{\listdoubleitemcolumnwidth}
-\@initializelength{\listitemsymbolspace}          \settowidth{\listitemsymbolspace}{0pt}
+\@initializelength{\listitemsymbolspace}          \setlength{\listitemsymbolspace}{0pt}
 
 % commands
 \renewcommand*{\recomputecvbodylengths}{%

--- a/moderncvbodyiv.sty
+++ b/moderncvbodyiv.sty
@@ -49,7 +49,7 @@
 \@initializelength{\listitemcolumnwidth}
 %   used by \cvlistdoubleitem
 \@initializelength{\listdoubleitemcolumnwidth}
-\@initializelength{\listitemsymbolspace}          \settowidth{\listitemsymbolspace}{0pt}
+\@initializelength{\listitemsymbolspace}          \setlength{\listitemsymbolspace}{0pt}
 
 % commands
 \renewcommand*{\recomputecvbodylengths}{%

--- a/moderncvbodyv.sty
+++ b/moderncvbodyv.sty
@@ -53,7 +53,7 @@
 %   used by \cvlistdoubleitem
 \@initializelength{\listdoubleitemcolumnwidth}
 %\@initializelength{\listdoubleitemmaincolumnwidth}
-\@initializelength{\listitemsymbolspace}          \settowidth{\listitemsymbolspace}{0pt}
+\@initializelength{\listitemsymbolspace}          \setlength{\listitemsymbolspace}{0pt}
 
 % commands
 \@initializecommand{\recomputecvbodylengths}{%

--- a/moderncvbodyvi.sty
+++ b/moderncvbodyvi.sty
@@ -53,7 +53,7 @@
 \@initializelength{\listitemcolumnwidth}
 %   used by \cvlistdoubleitem
 \@initializelength{\listdoubleitemcolumnwidth}
-\@initializelength{\listitemsymbolspace}          \settowidth{\listitemsymbolspace}{0pt}
+\@initializelength{\listitemsymbolspace}          \setlength{\listitemsymbolspace}{0pt}
 %   default moderncv \photo (change the definition such that by default the photo and its box align with the section bars
 \RenewDocumentCommand{\photo}{O{\hintscolumnwidth-0.8pt-2\fboxsep}O{0.4pt}m}{\def\@photowidth{#1}\def\@photoframewidth{#2}\def\@photo{#3}}%
 


### PR DESCRIPTION
This PR resolves #188. Unfortunately I introduced a bug with #182 due to a wrong initialization of `\listitemsymbolspace`. 
I recently discovered it and felt that it should be documented in a separate PR to keep changes clear. 

Hope the described issue is reproducible and maybe there is someone willing to review this topic. That would be great! Thanks in advance. 