### PR TITLE
Change GitHub actions to @ v4

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -16,20 +16,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build pdf
         run: latexmk -pdflua ./template.tex
 
       - name: Upload pdf
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: template.pdf
           path: ./template.pdf
 
       - name: Upload log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: template.log
           path: ./template.log


### PR DESCRIPTION
Node.js 16 to 20 change on GitHub`s side. @ v3 of "upload" will be obsolete in November, 2024 (see. https://github.com/actions/upload-artifact).

Changed it to @ v4.
