### PR TITLE
Rename moderncvcolors from .tex to .sty for MiKTeX compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+version next
+- Change moderncvcolors.tex to a .sty file for MikTeX compatibility (#199)
+
 version 2.4.1 (18 Jul 2024)
 - Fix commons/colors.tex not found in package (#194)
 

--- a/moderncvcolorblack.sty
+++ b/moderncvcolorblack.sty
@@ -16,7 +16,7 @@
 %-------------------------------------------------------------------------------
 %                color scheme definition
 %-------------------------------------------------------------------------------
-\input{moderncvcolors.tex}
+\usepackage{moderncvcolors}
 
 \colorlet{color0}{black}% black
 \colorlet{color1}{black}% black

--- a/moderncvcolorblue.sty
+++ b/moderncvcolorblue.sty
@@ -16,7 +16,7 @@
 %-------------------------------------------------------------------------------
 %                color scheme definition
 %-------------------------------------------------------------------------------
-\input{moderncvcolors.tex}
+\usepackage{moderncvcolors}
 
 \colorlet{color0}{black}% black
 \colorlet{color1}{lightblue}% light blue

--- a/moderncvcolorburgundy.sty
+++ b/moderncvcolorburgundy.sty
@@ -16,7 +16,7 @@
 %-------------------------------------------------------------------------------
 %                color scheme definition
 %-------------------------------------------------------------------------------
-\input{moderncvcolors.tex}
+\usepackage{moderncvcolors}
 
 \colorlet{color0}{black}% black
 \colorlet{color1}{burgundy}% burgundy

--- a/moderncvcolorgreen.sty
+++ b/moderncvcolorgreen.sty
@@ -16,7 +16,7 @@
 %-------------------------------------------------------------------------------
 %                color scheme definition
 %-------------------------------------------------------------------------------
-\input{moderncvcolors.tex}
+\usepackage{moderncvcolors}
 
 \colorlet{color0}{black}% black
 \colorlet{color1}{green}% green

--- a/moderncvcolorgrey.sty
+++ b/moderncvcolorgrey.sty
@@ -16,7 +16,7 @@
 %-------------------------------------------------------------------------------
 %                color scheme definition
 %-------------------------------------------------------------------------------
-\input{moderncvcolors.tex}
+\usepackage{moderncvcolors}
 
 \colorlet{color0}{black}% black
 \colorlet{color1}{darkgrey}% dark grey

--- a/moderncvcolororange.sty
+++ b/moderncvcolororange.sty
@@ -16,7 +16,7 @@
 %-------------------------------------------------------------------------------
 %                color scheme definition
 %-------------------------------------------------------------------------------
-\input{moderncvcolors.tex}
+\usepackage{moderncvcolors}
 
 \colorlet{color0}{black}% black
 \colorlet{color1}{orange}% orange

--- a/moderncvcolorpurple.sty
+++ b/moderncvcolorpurple.sty
@@ -16,7 +16,7 @@
 %-------------------------------------------------------------------------------
 %                color scheme definition
 %-------------------------------------------------------------------------------
-\input{moderncvcolors.tex}
+\usepackage{moderncvcolors}
 
 \colorlet{color0}{black}% black
 \colorlet{color1}{purple}% purple

--- a/moderncvcolorred.sty
+++ b/moderncvcolorred.sty
@@ -16,7 +16,7 @@
 %-------------------------------------------------------------------------------
 %                color scheme definition
 %-------------------------------------------------------------------------------
-\input{moderncvcolors.tex}
+\usepackage{moderncvcolors}
 
 \colorlet{color0}{black}% black
 \colorlet{color1}{red}% red

--- a/moderncvcolors.sty
+++ b/moderncvcolors.sty
@@ -1,3 +1,17 @@
+%% start of file `moderncvcolors.sty'.
+%% Copyright 2006-2015 Xavier Danaux (xdanaux@gmail.com)
+%% Copyright 2024-2024 moderncv maintainers (github.com/moderncv).
+%
+% This work may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License version 1.3c,
+% available at http://www.latex-project.org/lppl/.
+
+%-------------------------------------------------------------------------------
+%                identification
+%-------------------------------------------------------------------------------
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{moderncvcolors}[2024-07-18 v2.4.1 modern curriculum vitae and letter base colors]
+
 %-------------------------------------------------------------------------------
 % built-in colors
 %-------------------------------------------------------------------------------
@@ -33,3 +47,5 @@
 %-------------------------------------------------------------------------------
 
 % \definecolor{tsinghua}{HTML}{791CB5}
+
+%% end of file `moderncvcolors.sty'.

--- a/moderncviconsacademic.sty
+++ b/moderncviconsacademic.sty
@@ -23,7 +23,7 @@
 %-------------------------------------------------------------------------------
 %                set colors
 %-------------------------------------------------------------------------------
-\input{moderncvcolors.tex}
+\usepackage{moderncvcolors}
 
 \providecolor{orcid}{named}{default-socialicon-color}
 \providecolor{researchgate}{named}{default-socialicon-color}

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -22,7 +22,7 @@
 %-------------------------------------------------------------------------------
 %                set colors
 %-------------------------------------------------------------------------------
-\input{moderncvcolors.tex}
+\usepackage{moderncvcolors}
 
 \providecolor{address}{named}{default-socialicon-color}
 \providecolor{mobilephone}{named}{default-socialicon-color}


### PR DESCRIPTION
Reported with #199 it seems that MiKTeX ignores runtime relevant `.tex` files. 
This PR changes `moderncvcolors.tex` it to a `.sty` and adjusts the includes correspondingly. 