### PR TITLE
In case no photo is set: define photoframewidth nevertheless

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+version next
+- Fix error when omitting the photo in contemporary style (#201)
+
 version 2.4.1 (18 Jul 2024)
 - Fix commons/colors.tex not found in package (#194)
 

--- a/moderncvheadvii.sty
+++ b/moderncvheadvii.sty
@@ -145,6 +145,8 @@
     % Users may define `\@moderncvheadBackground` for additional background decoration
     \ifthenelse{\isundefined{\@moderncvheadBackground}}{}{\@moderncvheadBackground}
 
+    % case with no photo: assure defined \@photoframewidth with 2pt
+    \ifthenelse{\isundefined{\@photo}}{\@initializelength{\@photoframewidth}\setlength{\@photoframewidth}{2pt}}{}%
     \path[draw,line width=\@photoframewidth]
         (head-bg.south west) edge[color=headhr!85!black] ([xshift=8em]head-bg.south west)
         ([xshift=8em]head-bg.south west) edge[color=headhr] ([xshift=-8em]head-bg.south east)


### PR DESCRIPTION
`\@photoframewidth` is used regardless of the `\@photo` macro. This led to errors when omitting the photo as described in #201. 
Therefore define `\@photoframewidth` in either case: "photo" and "no photo"