### PR TITLE
All colors for all styles

### DIFF
--- a/moderncvcolorblack.sty
+++ b/moderncvcolorblack.sty
@@ -18,10 +18,13 @@
 %-------------------------------------------------------------------------------
 \usepackage{moderncvcolors}
 
-\colorlet{color0}{black}% black
-\colorlet{color1}{black}% black
-\colorlet{color2}{black}% black
-
+\colorlet{color0}{black}
+\colorlet{color1}{black}
+\colorlet{color2}{black}
+\colorlet{headTL}{lightblack}
+\colorlet{headBR}{color1}
+\colorlet{headtext}{white}
+\colorlet{headhr}{color2}
 
 \endinput
 

--- a/moderncvcolorblue.sty
+++ b/moderncvcolorblue.sty
@@ -18,9 +18,13 @@
 %-------------------------------------------------------------------------------
 \usepackage{moderncvcolors}
 
-\colorlet{color0}{black}% black
-\colorlet{color1}{lightblue}% light blue
-\colorlet{color2}{darkgrey}% dark grey
+\colorlet{color0}{black}
+\colorlet{color1}{lightblue}
+\colorlet{color2}{darkgrey}
+\colorlet{headTL}{lightskyblue}
+\colorlet{headBR}{color1}
+\colorlet{headtext}{white}
+\colorlet{headhr}{color2}
 
 
 \endinput

--- a/moderncvcolorburgundy.sty
+++ b/moderncvcolorburgundy.sty
@@ -18,10 +18,13 @@
 %-------------------------------------------------------------------------------
 \usepackage{moderncvcolors}
 
-\colorlet{color0}{black}% black
-\colorlet{color1}{burgundy}% burgundy
-\colorlet{color2}{darkgrey}% dark grey
-
+\colorlet{color0}{black}
+\colorlet{color1}{burgundy}
+\colorlet{color2}{darkgrey}
+\colorlet{headTL}{darkred}
+\colorlet{headBR}{color1}
+\colorlet{headtext}{white}
+\colorlet{headhr}{color2}
 
 \endinput
 

--- a/moderncvcolorcerulean.sty
+++ b/moderncvcolorcerulean.sty
@@ -17,14 +17,15 @@
 %-------------------------------------------------------------------------------
 %                color scheme definition
 %-------------------------------------------------------------------------------
-\definecolor{color0}{rgb}{0,0,0}% black
-\definecolor{color1}{HTML}{0081a7}% cerulean
-\definecolor{color2}{HTML}{4d908e}% dark cyan
-\definecolor{headTL}{HTML}{00afb9}% verdigris
-\colorlet{headBR}{color1}
-\definecolor{headtext}{HTML}{ffffff}% white
-\colorlet{headhr}{color2}
+\usepackage{moderncvcolors}
 
+\colorlet{color0}{black}
+\colorlet{color1}{cerulean}
+\colorlet{color2}{darkcyan}
+\colorlet{headTL}{verdigris}
+\colorlet{headBR}{color1}
+\colorlet{headtext}{white}
+\colorlet{headhr}{color2}
 
 \endinput
 

--- a/moderncvcolorgreen.sty
+++ b/moderncvcolorgreen.sty
@@ -18,9 +18,13 @@
 %-------------------------------------------------------------------------------
 \usepackage{moderncvcolors}
 
-\colorlet{color0}{black}% black
-\colorlet{color1}{green}% green
-\colorlet{color2}{darkgrey}% dark grey
+\colorlet{color0}{black}
+\colorlet{color1}{green}
+\colorlet{color2}{darkgrey}
+\colorlet{headTL}{palegreen}
+\colorlet{headBR}{color1}
+\colorlet{headtext}{white}
+\colorlet{headhr}{color2}
 
 
 \endinput

--- a/moderncvcolorgrey.sty
+++ b/moderncvcolorgrey.sty
@@ -18,10 +18,13 @@
 %-------------------------------------------------------------------------------
 \usepackage{moderncvcolors}
 
-\colorlet{color0}{black}% black
-\colorlet{color1}{darkgrey}% dark grey
-\colorlet{color2}{darkgrey}% dark grey
-
+\colorlet{color0}{black}
+\colorlet{color1}{darkgrey}
+\colorlet{color2}{darkgrey}
+\colorlet{headTL}{lightgrey}
+\colorlet{headBR}{color1}
+\colorlet{headtext}{white}
+\colorlet{headhr}{color2}
 
 \endinput
 

--- a/moderncvcolororange.sty
+++ b/moderncvcolororange.sty
@@ -18,10 +18,13 @@
 %-------------------------------------------------------------------------------
 \usepackage{moderncvcolors}
 
-\colorlet{color0}{black}% black
-\colorlet{color1}{orange}% orange
-\colorlet{color2}{darkgrey}% dark grey
-
+\colorlet{color0}{black}
+\colorlet{color1}{orange}
+\colorlet{color2}{darkgrey}
+\colorlet{headTL}{lightorange}
+\colorlet{headBR}{color1}
+\colorlet{headtext}{white}
+\colorlet{headhr}{color2}
 
 \endinput
 

--- a/moderncvcolorpurple.sty
+++ b/moderncvcolorpurple.sty
@@ -18,9 +18,13 @@
 %-------------------------------------------------------------------------------
 \usepackage{moderncvcolors}
 
-\colorlet{color0}{black}% black
-\colorlet{color1}{purple}% purple
-\colorlet{color2}{darkgrey}% dark grey
+\colorlet{color0}{black}
+\colorlet{color1}{purple}
+\colorlet{color2}{darkgrey}
+\colorlet{headTL}{lavender}
+\colorlet{headBR}{color1}
+\colorlet{headtext}{white}
+\colorlet{headhr}{color2}
 
 
 \endinput

--- a/moderncvcolorred.sty
+++ b/moderncvcolorred.sty
@@ -18,9 +18,13 @@
 %-------------------------------------------------------------------------------
 \usepackage{moderncvcolors}
 
-\colorlet{color0}{black}% black
-\colorlet{color1}{red}% red
-\colorlet{color2}{darkgrey}% dark grey
+\colorlet{color0}{black}
+\colorlet{color1}{red}
+\colorlet{color2}{darkgrey}
+\colorlet{headTL}{firebrick}
+\colorlet{headBR}{color1}
+\colorlet{headtext}{white}
+\colorlet{headhr}{color2}
 
 
 \endinput

--- a/moderncvcolors.sty
+++ b/moderncvcolors.sty
@@ -30,7 +30,8 @@
 \definecolor{darkcyan}{HTML}{4d908e}
 \definecolor{verdigris}{HTML}{00afb9}
 \definecolor{lightskyblue}{HTML}{b1dffc}
-\definecolor{darkred}{HTML}{d60000}%960018 ab2121
+\definecolor{darkred}{HTML}{d60000}
+\definecolor{palegreen}{HTML}{a6fca6}
 
 
 %-------------------------------------------------------------------------------

--- a/moderncvcolors.sty
+++ b/moderncvcolors.sty
@@ -32,6 +32,7 @@
 \definecolor{lightskyblue}{HTML}{b1dffc}
 \definecolor{darkred}{HTML}{d60000}
 \definecolor{palegreen}{HTML}{a6fca6}
+\definecolor{lightorange}{HTML}{ffbb3d}
 
 
 %-------------------------------------------------------------------------------

--- a/moderncvcolors.sty
+++ b/moderncvcolors.sty
@@ -29,6 +29,7 @@
 \definecolor{cerulean}{HTML}{0081a7}
 \definecolor{darkcyan}{HTML}{4d908e}
 \definecolor{verdigris}{HTML}{00afb9}
+\definecolor{lightskyblue}{HTML}{b1dffc}
 
 
 %-------------------------------------------------------------------------------

--- a/moderncvcolors.sty
+++ b/moderncvcolors.sty
@@ -35,6 +35,7 @@
 \definecolor{lightorange}{HTML}{ffbb3d}
 \definecolor{lavender}{HTML}{9090e9}
 \definecolor{firebrick}{HTML}{ce2727}
+\definecolor{lightblack}{HTML}{3d3d3d}
 
 
 %-------------------------------------------------------------------------------

--- a/moderncvcolors.sty
+++ b/moderncvcolors.sty
@@ -17,13 +17,19 @@
 %-------------------------------------------------------------------------------
 
 \definecolor{black}{RGB}{0, 0, 0}
+\definecolor{white}{HTML}{ffffff}
 \definecolor{red}{rgb}{0.95, 0.20, 0.20}
 \definecolor{darkgrey}{rgb}{0.45, 0.45, 0.45}
+\definecolor{lightgrey}{HTML}{d3d3d3}
 \definecolor{orange}{rgb}{0.95, 0.55, 0.15}
 \definecolor{burgundy}{rgb}{0.596078, 0, 0}% 139/255 (0.545098) or 152/255 (0.596078)
 \definecolor{purple}{rgb}{0.50, 0.33, 0.80}
 \definecolor{lightblue}{rgb}{0.22, 0.45, 0.70}
 \definecolor{green}{rgb}{0.35, 0.70, 0.30}
+\definecolor{cerulean}{HTML}{0081a7}
+\definecolor{darkcyan}{HTML}{4d908e}
+\definecolor{verdigris}{HTML}{00afb9}
+
 
 %-------------------------------------------------------------------------------
 % default colors

--- a/moderncvcolors.sty
+++ b/moderncvcolors.sty
@@ -33,6 +33,7 @@
 \definecolor{darkred}{HTML}{d60000}
 \definecolor{palegreen}{HTML}{a6fca6}
 \definecolor{lightorange}{HTML}{ffbb3d}
+\definecolor{lavender}{HTML}{9090e9}
 
 
 %-------------------------------------------------------------------------------

--- a/moderncvcolors.sty
+++ b/moderncvcolors.sty
@@ -30,6 +30,7 @@
 \definecolor{darkcyan}{HTML}{4d908e}
 \definecolor{verdigris}{HTML}{00afb9}
 \definecolor{lightskyblue}{HTML}{b1dffc}
+\definecolor{darkred}{HTML}{d60000}%960018 ab2121
 
 
 %-------------------------------------------------------------------------------

--- a/moderncvcolors.sty
+++ b/moderncvcolors.sty
@@ -34,6 +34,7 @@
 \definecolor{palegreen}{HTML}{a6fca6}
 \definecolor{lightorange}{HTML}{ffbb3d}
 \definecolor{lavender}{HTML}{9090e9}
+\definecolor{firebrick}{HTML}{ce2727}
 
 
 %-------------------------------------------------------------------------------

--- a/moderncvstylecontemporary.sty
+++ b/moderncvstylecontemporary.sty
@@ -39,7 +39,7 @@
 %\fi
 
 % symbols
-\providecolor{default-socialicon-color}{named}{headtext}
+\definecolor{default-socialicon-color}{named}{headtext}
 \moderncvicons{symbols}
 
 %-------------------------------------------------------------------------------


### PR DESCRIPTION
Proposal to make all colors usable with contemporary style and also make cerulean usable for all other styles.

I am not sure what the difference is between `\providecolor` and `\definecolor` but I had to adjust that in the `moderncvstylecontemporary.sty`. This helped to really take white for the symbols in case of *contemporary* style and letting it to `darkgrey` for all other styles. 

I also transferred the color definitions of specific `moderncvcolor<color>.sty` to the more general `moderncvcolors.sty`.