### PR TITLE
Allowing long names to break in the cv title again

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ version next
 - Fix spacing between first and last name (#204)
 - Include social icons in cover letter for styles classic, fancy and banking (#170)
 - Update Oldstyle to use symbols instead of marvosym (#209)
+- Fix spacing between first and last name again (#220)
 
 version 2.4.1 (18 Jul 2024)
 - Fix commons/colors.tex not found in package (#194)

--- a/moderncvheadi.sty
+++ b/moderncvheadi.sty
@@ -120,7 +120,7 @@
     \begin{minipage}[b]{\makecvheadnamewidth}%
       \if@left\raggedright\fi%
       \if@right\raggedleft\fi%
-      \firstnamestyle{\@firstname~}\lastnamestyle{\@lastname}%
+      \firstnamestyle{\@firstname\ }\lastnamestyle{\@lastname}%
       \ifthenelse{\equal{\@title}{}}{}{\\[1.25em]\titlestyle{\@title}}%
     \end{minipage}}%
   % raise boxes if top option is set

--- a/moderncvheadiii.sty
+++ b/moderncvheadiii.sty
@@ -83,7 +83,7 @@
   \parbox{\makeheaddetailswidth}{%
     \centering%
     % name and title
-    \firstnamestyle{\@firstname~}\lastnamestyle{\@lastname}%
+    \firstnamestyle{\@firstname\ }\lastnamestyle{\@lastname}%
     \ifthenelse{\equal{\@title}{}}{}{\titlestyle{~|~\@title}}% \isundefined doesn't work on \@title, as LaTeX itself defines \@title (before it possibly gets redefined by \title)
     % optional detailed information
     \if@details{%

--- a/moderncvheadiv.sty
+++ b/moderncvheadiv.sty
@@ -93,7 +93,7 @@
     {\setlength{\makecvheadnamewidth}{\textwidth-\makecvheadpicturewidth}}%
     {}%
   \begin{minipage}[b]{\makecvheadnamewidth}%
-    \firstnamestyle{\@firstname~}\lastnamestyle{\@lastname}%
+    \firstnamestyle{\@firstname\ }\lastnamestyle{\@lastname}%
     \ifthenelse{\equal{\@title}{}}{}{\\[1.25em]\titlestyle{\@title}}%
   \end{minipage}%
   % optional photo

--- a/moderncvheadv.sty
+++ b/moderncvheadv.sty
@@ -94,7 +94,7 @@
       % name and optional title
       \newlength{\makecvheadpictureboxskip}%
       \setlength{\makecvheadpictureboxskip}{\totalheightof{\usebox{\makecvheadpicturebox}}}%
-      \firstnamestyle{\@firstname~}\lastnamestyle{\@lastname}%
+      \firstnamestyle{\@firstname\ }\lastnamestyle{\@lastname}%
 	  \ifthenelse{\equal{\@title}{}}{
 	    \ifthenelse{\isundefined{\@quote}}%
         {}%

--- a/moderncvheadvi.sty
+++ b/moderncvheadvi.sty
@@ -55,7 +55,7 @@
   \setlength{\makeheaddetailswidth}{\textwidth}%
   % name and title
   \if@left\hfill\fi%
-  \firstnamestyle{\@firstname~}\lastnamestyle{\@lastname}%
+  \firstnamestyle{\@firstname\ }\lastnamestyle{\@lastname}%
   \ifthenelse{\equal{\@title}{}}{}{\titlestyle{~|~\@title}}\\[-.35em]% \isundefined doesn't work on \@title, as LaTeX itself defines \@title (before it possibly gets redefined by \title)
   % rule
   {\color{bodyrulecolor}\rule{\textwidth}{.25ex}}}


### PR DESCRIPTION
Until now, a `~` (non breaking space) connects first and last name in the cv title. This prevents long names to break correctly. This commit replaces the space with `\ `, a space that allows breaking.

Fixes https://github.com/moderncv/moderncv/issues/220