### PR TITLE
Fix tikz icon color when using contemporary style

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ version next
 - Fix spacing between first and last name (#204)
 - Include social icons in cover letter for styles classic, fancy and banking (#170)
 - Update Oldstyle to use symbols instead of marvosym (#209)
+- Fix tikz icon color in contemporary style (#224)
 
 version 2.4.1 (18 Jul 2024)
 - Fix commons/colors.tex not found in package (#194)

--- a/moderncviconstikz.sty
+++ b/moderncviconstikz.sty
@@ -29,7 +29,7 @@
     \protect\raisebox{-0.165em}{
     \protect\begin{tikzpicture}[x=0.08em, y=0.08em, xscale=0.25, yscale=-0.25, inner sep=0pt, outer sep=0pt]
       \protect\begin{scope}[cm={{0.60,0.0,0.0,0.60,(346.39,123.07)}}]
-        \protect\path[fill=color2]
+        \protect\path[fill=default-socialicon-color]
           (381,202) -- (434,202) .. controls (439,202) and (442,205) ..
           (442,210) -- (442,264) .. controls (442,268) and (439,272) ..
           (434,272) -- (381,272) .. controls (376,272) and (372,268) ..
@@ -74,7 +74,7 @@
   \renewcommand*{\twittersocialsymbol} {
     \protect\raisebox{0em}{%
     \protect\begin{tikzpicture}[x=0.08em, y=0.08em, xscale=0.005, yscale=-0.005, inner sep=0pt, outer sep=0pt]
-      \protect\path[fill=color2]
+      \protect\path[fill=default-socialicon-color]
         (2000, 192) .. controls (1926, 225) and (1847, 247) ..
         (1764, 257) .. controls (1849, 206) and (1914, 126) ..
         (1945,  30) .. controls (1865,  77) and (1778, 111) ..
@@ -106,7 +106,7 @@
     \protect\raisebox{-0.15em} {
     \protect\begin{tikzpicture}[x=0.08em, y=0.08em, xscale=0.25, yscale=-0.25, inner sep=0pt, outer sep=0pt]
       \protect\begin{scope}[shift={(507,387)}]
-        \protect\path[fill=color2]
+        \protect\path[fill=default-socialicon-color]
           (117, 60) .. controls (117, 71) and (108, 81) ..
           ( 96, 81) .. controls ( 85, 81) and ( 75, 71) ..
           ( 75, 60) .. controls ( 75, 48) and ( 85, 39) ..
@@ -118,7 +118,7 @@
           ( 75, 60) .. controls ( 75, 48) and ( 85, 39) ..
           ( 96, 39) .. controls (108, 39) and (117, 48) ..
           (117, 60) -- cycle;
-        \protect\path[fill=color2, nonzero rule]
+        \protect\path[fill=default-socialicon-color, nonzero rule]
           (103, 45) .. controls (103, 45) and (101, 46) ..
           (101, 47) -- (100, 47) --
           ( 99, 47) .. controls ( 99, 47) and ( 98, 47) ..
@@ -217,7 +217,7 @@
     \protect\raisebox{-0.12em}{
       \protect\begin{tikzpicture}[x=0.11em, y=0.11em, xscale=0.015, yscale=-0.015, inner sep=0pt, outer sep=0pt]
       \protect\begin{scope}[shift={(507,387)}]
-      \protect\path[fill=color2,line width=0.057pt]
+      \protect\path[fill=default-socialicon-color,line width=0.057pt]
       (105.2000,24.9000) .. controls (102.1000,16.0000) and (89.5000,16.0000) ..
       (86.3000,24.9000) -- (29.8000,199.7000) -- (161.7000,199.7000) .. controls
       (161.7000,199.7000) and (105.2000,24.9000) .. (105.2000,24.9000) -- cycle
@@ -238,7 +238,7 @@
   \protect\raisebox{-0.15em}{
     \protect\begin{tikzpicture}[y=0.08em, x=0.08em, xscale=0.020, yscale=-0.020, inner sep=0pt, outer sep=0pt]
       \protect\begin{scope}[shift={(507,387)}]
-        \protect\path[fill=color2,even odd rule]
+        \protect\path[fill=default-socialicon-color,even odd rule]
           (487.6550,288.9690) .. controls (489.0610,278.5690) and (489.8700,267.9960) ..
           (489.8700,257.2330) .. controls (489.8700,128.0770) and (384.5990,23.3610) ..
           (254.7670,23.3610) .. controls (241.8630,23.3610) and (229.2120,24.4210) ..
@@ -274,7 +274,7 @@
     \protect\raisebox{-0.12em}{
     \protect\begin{tikzpicture}[y=2.0pt, x=2.0pt, yscale=-0.1, xscale=0.1, inner sep=0pt, outer sep=0pt]
     \protect\begin{scope}[shift={(507,387)}]
-    \protect\path[fill=color2] (25.0000,2.0000) .. controls (12.3095,2.0000) and (2.0000,12.3095)
+    \protect\path[fill=default-socialicon-color] (25.0000,2.0000) .. controls (12.3095,2.0000) and (2.0000,12.3095)
 		.. (2.0000,25.0000) .. controls (2.0000,37.6905) and (12.3095,48.0000) ..
 		(25.0000,48.0000) .. controls (37.6905,48.0000) and (48.0000,37.6905) ..
 		(48.0000,25.0000) .. controls (48.0000,12.3095) and (37.6905,2.0000) ..
@@ -327,7 +327,7 @@
     \protect\raisebox{-0.12em}{
     \protect\begin{tikzpicture}[y=1.8pt, x=1.8pt, yscale=-0.15, xscale=0.15, inner sep=0pt, outer sep=0pt]
     \protect\begin{scope}[shift={(507,387)}]
-    \protect\path[fill=color2]
+    \protect\path[fill=default-socialicon-color]
       (0.9360,0.7320) .. controls (0.9360,10.9053) and (0.9360,21.0787) ..
       (0.9360,31.2520) .. controls (1.6673,31.2520) and (2.3987,31.2520) ..
       (3.1300,31.2520) .. controls (3.3452,32.0075) and (2.8778,32.0803) ..
@@ -374,7 +374,7 @@
     \protect\raisebox{-0.12em}{
     \protect\begin{tikzpicture}[y=0.1pt, x=0.1pt, yscale=-0.13, xscale=0.13, inner sep=0pt, outer sep=0pt]
     \protect\begin{scope}[shift={(507,387)}]
-    \protect\path[fill=color2]
+    \protect\path[fill=default-socialicon-color]
       (430.1000,180.9000) -- (437.8000,211.9000) .. controls (407.6000,219.3000)
       and (378.7000,231.3000) .. (352.1000,247.3000) -- (335.7000,220.0000) ..
       controls (365.0000,202.3000) and (396.9000,189.1000) .. (430.1000,180.9000) --
@@ -449,7 +449,7 @@
       (11258.5852,-1839.4433)arc(66.699:32.084:23.067) --
       (11250.0698,-1872.8557)arc(329.460:269.346:0.201313 and 0.150) -- cycle;
 
-      \protect\path[scale=0.265, fill=color2, line width=0.426pt]
+      \protect\path[scale=0.265, fill=default-socialicon-color, line width=0.426pt]
       (11249.3743,-1883.6959)arc(269.785:180.000:23.067)arc(180.001:147.920:23.067)
       -- (11249.1480,-1873.2412)arc(209.929:330.071:0.360097 and 0.269) --
       (11269.0053,-1848.3766)arc(32.082:-0.002:23.067)arc(360.000:270.000:23.067)arc(270.108:269.892:23.067)


### PR DESCRIPTION
Currently the _contemporary_ style uses a different social icon color. 
At the moment this will result in unwanted gray symbols for the tikz icons. Compared to all others the color is white.

This PR tries is intended to fix that when using the `default-socialicon-color` instead of `color2`. 