### PR TITLE
Make header details flush against sides

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ version next
 - Include social icons in cover letter for styles classic, fancy and banking (#170)
 - Update Oldstyle to use symbols instead of marvosym (#209)
 - Fix spacing between first and last name again (#220)
+- Make header details flush against sides for casual, classic, and contemporary
+  styles (#229)
 
 version 2.4.1 (18 Jul 2024)
 - Fix commons/colors.tex not found in package (#194)

--- a/moderncvheadi.sty
+++ b/moderncvheadi.sty
@@ -92,7 +92,7 @@
           \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}%
         \socialsdetails% needs to be pre-rendered as loops and tabulars seem to conflict
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}%
-      \end{tabular}
+      \end{tabular}%
     }\fi%
   % optional photo (pre-rendering)
   \@initializebox{\makecvheadpicturebox}%
@@ -106,9 +106,9 @@
         \setlength{\fboxrule}{\@photoframewidth}%
         \ifdim\@photoframewidth=0pt%
           \setlength{\fboxsep}{0pt}\fi%
-        \framebox{\includegraphics[width=\@photowidth]{\@photo}}}%
+        \framebox{\includegraphics[width=\@photowidth]{\@photo}}%
         \if@right%
-          \hspace*{\separatorcolumnwidth}\fi}%
+          \hspace*{\separatorcolumnwidth}\fi}}%
   % name and title (pre-rendering)
   \@initializelength{\makecvheaddetailswidth}\settowidth{\makecvheaddetailswidth}{\usebox{\makecvheaddetailsbox}}%
   \@initializelength{\makecvheadpicturewidth}\settowidth{\makecvheadpicturewidth}{\usebox{\makecvheadpicturebox}}%

--- a/moderncvheadvii.sty
+++ b/moderncvheadvii.sty
@@ -97,7 +97,7 @@
         \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol\httplink{\@homepage}}%
         \socialsdetails% needs to be pre-rendered as loops and tabulars seem to conflict
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}%
-      \end{tabular}
+      \end{tabular}%
     }\fi%
   % optional photo (pre-rendering)
   \@initializebox{\makecvheadpicturebox}%
@@ -115,9 +115,9 @@
             \node[inner sep=0pt] at (0,0) {\includegraphics[width=\@photowidth]{\@photo}};
           \end{scope}
         \end{tikzpicture}%
+        \if@left%
+          \hspace*{\separatorcolumnwidth}\fi}%
       }%
-      \if@left%
-        \hspace*{\separatorcolumnwidth}\fi}%
   % optional QR for homepage (pre-rendering)
   \@initializebox{\makecvheadqrbox}%
   \if@headqr%


### PR DESCRIPTION
This PR fixes the following issues:

1. When using the `right` option and no photo is specified, the contact details appears `\separatorcolumnwidth` to the right of the left margin, rather than being flush with it. This looks out of place since the section header lines clearly define the margin.
2. When using the `left` option, an extra space appears between the contact details and whatever is to the right (the photo or else the right margin). This space is technically there with the `right` option as well but doesn't affect anything since the box is wrapped in `\rlap`.