### PR TITLE
Use texlive image from island of tex

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build template
     runs-on: ubuntu-latest
     container:
-      image: thomasweise/docker-texlive-full:latest
+      image: texlive/texlive:latest-full
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-userguide-pdf.yml
+++ b/.github/workflows/build-userguide-pdf.yml
@@ -18,7 +18,7 @@ jobs:
       UG_AUTHOR: Auto Userguide Creator
       UG_COMMIT_MESSAGE: <automated> build of user guide
     container:
-      image: thomasweise/docker-texlive-full:latest
+      image: texlive/texlive:latest-full
 
     steps:
       - name: Checkout source code


### PR DESCRIPTION
In order to get an more up to date `texlive` image for github actions this uses the [Island of TeX](https://gitlab.com/islandoftex/images/texlive) image. 