### PR TITLE
Make born asterisk icon tiny (instead of small)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@ version next
 - Upgrade to Fontawesome 6 (#183)
 - Document how to set custom strings for social command (#239)
 - Correct documentation to reflect new order \moderncvcolor before \moderncvstyle (#256)
+- Decreasing the size of born symbol to "tiny" and rasing it by .5ex,
+  to look typograpically more in line with born symbols outside moderncv (#273)
 
 version 2.5.1 (31 Jan 2026)
 - Fix french babel breaking contemporary style (#219)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ version next
 - Upgrade to Fontawesome 6 (#183)
 - Document how to set custom strings for social command (#239)
 - Correct documentation to reflect new order \moderncvcolor before \moderncvstyle (#256)
-- Decreasing the size of born symbol to "tiny" and rasing it by .5ex,
+- Decreasing the size of born symbol to "tiny" and raising it by .5ex,
   to look typograpically more in line with born symbols outside moderncv (#273)
 
 version 2.5.1 (31 Jan 2026)

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -102,7 +102,7 @@
 %\renewcommand*{\matrixsocialsymbol}       {}
 % \renewcommand*{\arxivsocialsymbol}        {{\color{arxiv}{\small\faarXiv}}~}
 % \renewcommand*{\inspiresocialsymbol}      {{\color{inspire}{\small\faInspire}}~}
-\renewcommand*{\bornsymbol}               {{\color{born}\small\faAsterisk}~}           % alternative: \faBabyCarriage
+\renewcommand*{\bornsymbol}               {{\color{born}\tiny\faAsterisk}~}           % alternative: \faBabyCarriage
 \renewcommand*{\mediumsocialsymbol}     {{\color{medium}\small\faMedium}~}
 
 

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -102,7 +102,7 @@
 %\renewcommand*{\matrixsocialsymbol}       {}
 % \renewcommand*{\arxivsocialsymbol}        {{\color{arxiv}{\small\faarXiv}}~}
 % \renewcommand*{\inspiresocialsymbol}      {{\color{inspire}{\small\faInspire}}~}
-\renewcommand*{\bornsymbol}               {{\color{born}\tiny\faAsterisk}~}           % alternative: \faBabyCarriage
+\renewcommand*{\bornsymbol}               {{\color{born}\raisebox{.5ex}{\tiny\faAsterisk}}~}           % alternative: \faBabyCarriage
 \renewcommand*{\mediumsocialsymbol}     {{\color{medium}\small\faMedium}~}
 
 


### PR DESCRIPTION
The asterisk optically looks huge, even as "small". When using "tiny" it looks better.