### PR TITLE
Eliminate horizontal space for tikz icons

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ version next
 - Adding optional \postscript{PS text} command to cover letter in all current styles (#271)
 - Decreasing the size of born symbol to "tiny" and raising it by .5ex,
   to look typograpically more in line with born symbols outside moderncv (#273)
+- Eliminate extra horizontal space for tikz icons (#259)
 
 version 2.5.1 (31 Jan 2026)
 - Fix french babel breaking contemporary style (#219)

--- a/moderncvheadiv.sty
+++ b/moderncvheadiv.sty
@@ -116,7 +116,7 @@
       \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\hbox to 1.0em{\homepagesymbol}~%
         \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}%
       \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
-        \makenewline\hbox to 1.0em{\csname\collectionloopkey socialsymbol\endcsname}~\collectionloopitem}%
+        \makenewline\hbox to 1.0em{\hss\csname\collectionloopkey socialsymbol\endcsname\hss}~\collectionloopitem}%
       \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}\fi}
 
 
@@ -165,7 +165,7 @@
         \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\hbox to 1.0em{\homepagesymbol}~%
           \ifthenelse{\equal{\@homepageprotocol}{http}}{\httplink{\@homepage}}{\httpslink{\@homepage}}}%
         \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
-          \makenewline\hbox to 1.0em{\csname\collectionloopkey socialsymbol\endcsname}~\collectionloopitem}%
+          \makenewline\hbox to 1.0em{\hss\csname\collectionloopkey socialsymbol\endcsname\hss}~\collectionloopitem}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}}%
     % ensure no extra spacing after \makelettertitle due to a possible blank line
     %\ignorespacesafterend% not working

--- a/moderncviconsacademic.sty
+++ b/moderncviconsacademic.sty
@@ -28,7 +28,7 @@
 \providecolor{orcid}{named}{default-socialicon-color}
 \providecolor{researchgate}{named}{default-socialicon-color}
 \providecolor{researcherid}{named}{default-socialicon-color}
-\providecolor{googlescholar}{named}{default-socialicon-color}
+%\providecolor{googlescholar}{named}{default-socialicon-color}
 \providecolor{arxiv}{named}{default-socialicon-color}
 \providecolor{inspire}{named}{default-socialicon-color}
 
@@ -54,7 +54,7 @@
 \renewcommand*{\orcidsocialsymbol}        {{\color{orcid}\small\aiOrcid}~}
 \renewcommand*{\researchgatesocialsymbol} {{\color{researchgate}\small\aiResearchGateSquare}~} % alternative: \aiResearchGate
 \renewcommand*{\researcheridsocialsymbol} {{\color{researcherid}\small\aiResearcherIDSquare}~}       % alternative: \aiResearcherID
-\renewcommand*{\googlescholarsocialsymbol}{{\color{googlescholar}\raisebox{-1pt}{\large\aiGoogleScholar}}~}
+%\renewcommand*{\googlescholarsocialsymbol}{{\color{googlescholar}\raisebox{-1pt}{\large\aiGoogleScholar}}~}
 %\newcommand*{\telegramsocialsymbol}     {}
 %\newcommand*{\whatsappsocialsymbol}     {}
 %\newcommand*{\matrixsocialsymbol}       {}

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -85,7 +85,7 @@
 \renewcommand*{\orcidsocialsymbol}        {{\color{orcid}\small\faOrcid}~}
 \renewcommand*{\researchgatesocialsymbol} {{\color{researchgate}\small\faResearchgate}~}
 %\renewcommand*{\researcheridsocialsymbol} {}
-%\renewcommand*{\googlescholarsocialsymbol}{}
+\renewcommand*{\googlescholarsocialsymbol}{{\color{googlescholar}\small\faGoogleScholar}~}
 \renewcommand*{\telegramsocialsymbol}     {{\color{telegram}\small\faTelegram}~}
 \renewcommand*{\whatsappsocialsymbol}     {{\color{whatsapp}\small\faWhatsapp}~}
 \renewcommand*{\discordsocialsymbol}      {{\color{discord}\small\faDiscord}~}

--- a/moderncviconstikz.sty
+++ b/moderncviconstikz.sty
@@ -26,12 +26,6 @@
 %-------------------------------------------------------------------------------
 \usepackage{moderncvcolors}
 
-\providecolor{linkedin}{named}{default-socialicon-color}
-\providecolor{twitter}{named}{default-socialicon-color}
-\providecolor{github}{named}{default-socialicon-color}
-\providecolor{gitlab}{named}{default-socialicon-color}
-\providecolor{skype}{named}{default-socialicon-color}
-\providecolor{googlescholar}{named}{default-socialicon-color}
 \providecolor{matrix}{named}{default-socialicon-color}
 \providecolor{codeberg}{named}{default-socialicon-color}
 \providecolor{simplex}{named}{default-socialicon-color}
@@ -41,309 +35,12 @@
 %-------------------------------------------------------------------------------
 %                all symbols described in moderncv.cls
 %                only redefine symbols that are not defined at this level
+%                formula for trim right = (shift_x​ + scale * x_min​) * x_scale * x
 %-------------------------------------------------------------------------------
-\ifdefempty{\linkedinsocialsymbol} {
-  \renewcommand*{\linkedinsocialsymbol} {
-    \protect\raisebox{-0.165em}{
-    \protect\begin{tikzpicture}[x=0.08em, y=0.08em, xscale=0.25, yscale=-0.25, inner sep=0pt, outer sep=0pt]
-      \protect\begin{scope}[cm={{0.60,0.0,0.0,0.60,(346.39,123.07)}}]
-        \protect\path[fill=linkedin]
-          (381,202) -- (434,202) .. controls (439,202) and (442,205) ..
-          (442,210) -- (442,264) .. controls (442,268) and (439,272) ..
-          (434,272) -- (381,272) .. controls (376,272) and (372,268) ..
-          (372,264) -- (372,210) .. controls (372,205) and (376,202) ..
-          (381,202) -- cycle;
-        \protect\begin{scope}[xscale=0.98, yscale=1.02, fill=white]
-          \protect\path[fill=white]
-            (403,253) -- (403,224) -- (394,224) -- (394,253) --
-            cycle(398,211) .. controls (397,211) and (395,212) ..
-            (395,213) .. controls (394,213) and (393,215) ..
-            (393,216) .. controls (393,217) and (394,218) ..
-            (395,219) .. controls (395,220) and (397,220) ..
-            (398,220) .. controls (400,220) and (401,220) ..
-            (402,219) .. controls (402,218) and (403,217) ..
-            (403,216) .. controls (403,215) and (402,213) ..
-            (402,213) .. controls (401,212) and (400,211) ..
-            (398,211) -- cycle;
-          \protect\path[fill=white]
-            (410,253) -- (419,253) --
-            (419,236) .. controls (419,236) and (419,235) ..
-            (419,235) .. controls (419,235) and (419,234) ..
-            (419,234) .. controls (419,233) and (420,232) ..
-            (421,232) .. controls (422,231) and (423,231) ..
-            (424,231) .. controls (425,231) and (427,231) ..
-            (427,232) .. controls (428,234) and (428,235) ..
-            (428,237) -- (428,253) -- (437,253) --
-            (437,236) .. controls (437,232) and (436,228) ..
-            (434,226) .. controls (433,224) and (430,223) ..
-            (427,223) .. controls (425,223) and (423,224) ..
-            (421,225) .. controls (420,226) and (419,227) ..
-            (418,228) -- (418,228) -- (417,224) --
-            (410,224) .. controls (410,225) and (410,227) ..
-            (410,228) .. controls (410,230) and (410,231) ..
-            (410,233) -- cycle;
-        \protect\end{scope}
-      \protect\end{scope}
-    \protect\end{tikzpicture}}
-  ~}
-}{}\par
-
-\ifdefempty{\twittersocialsymbol} {
-  \renewcommand*{\twittersocialsymbol} {
-    \protect\raisebox{0em}{%
-    \protect\begin{tikzpicture}[x=0.08em, y=0.08em, xscale=0.005, yscale=-0.005, inner sep=0pt, outer sep=0pt]
-      \protect\path[fill=twitter]
-        (2000, 192) .. controls (1926, 225) and (1847, 247) ..
-        (1764, 257) .. controls (1849, 206) and (1914, 126) ..
-        (1945,  30) .. controls (1865,  77) and (1778, 111) ..
-        (1684, 130) .. controls (1609,  50) and (1503,   0) ..
-        (1385,   0) .. controls (1158,   0) and ( 974, 184) ..
-        ( 974, 410) .. controls ( 974, 442) and ( 978, 474) ..
-        ( 985, 504) .. controls ( 644, 487) and ( 342, 323) ..
-        ( 139,  75) .. controls ( 104, 136) and (  84, 206) ..
-        (  84, 281) .. controls (  84, 424) and ( 156, 549) ..
-        ( 266, 623) .. controls ( 199, 621) and ( 136, 602) ..
-        (  80, 572) .. controls (  80, 573) and (  80, 575) ..
-        (  80, 577) .. controls (  80, 776) and ( 222, 941) ..
-        ( 409, 979) .. controls ( 375, 988) and ( 339, 993) ..
-        ( 301, 993) .. controls ( 275, 993) and ( 249, 991) ..
-        ( 224, 986) .. controls ( 276,1149) and ( 428,1268) ..
-        ( 607,1271) .. controls ( 467,1381) and ( 290,1447) ..
-        (  98,1447) .. controls (  65,1447) and (  32,1445) ..
-        (   0,1441) .. controls ( 182,1557) and ( 397,1625) ..
-        ( 629,1625) .. controls (1384,1625) and (1796,1000) ..
-        (1796, 458) .. controls (1796, 440) and (1796, 422) ..
-        (1795, 405) .. controls (1875, 347) and (1945, 275) ..
-        (2000, 192);
-    \protect\end{tikzpicture}}
-  ~}
-}{}\par
-
-\ifdefempty{\githubsocialsymbol} {
-  \renewcommand*{\githubsocialsymbol} {
-    \protect\raisebox{-0.15em} {
-    \protect\begin{tikzpicture}[x=0.08em, y=0.08em, xscale=0.25, yscale=-0.25, inner sep=0pt, outer sep=0pt]
-      \protect\begin{scope}[shift={(507,387)}]
-        \protect\path[fill=github]
-          (117, 60) .. controls (117, 71) and (108, 81) ..
-          ( 96, 81) .. controls ( 85, 81) and ( 75, 71) ..
-          ( 75, 60) .. controls ( 75, 48) and ( 85, 39) ..
-          ( 96, 39) .. controls (108, 39) and (117, 48) ..
-          (117, 60) -- cycle;
-        \protect\path[cm={{0.88,0.0,0.0,0.88,(11.10,6.89)}}, fill=white]
-          (117, 60) .. controls (117, 71) and (108, 81) ..
-          ( 96, 81) .. controls ( 85, 81) and ( 75, 71) ..
-          ( 75, 60) .. controls ( 75, 48) and ( 85, 39) ..
-          ( 96, 39) .. controls (108, 39) and (117, 48) ..
-          (117, 60) -- cycle;
-        \protect\path[fill=github, nonzero rule]
-          (103, 45) .. controls (103, 45) and (101, 46) ..
-          (101, 47) -- (100, 47) --
-          ( 99, 47) .. controls ( 99, 47) and ( 98, 47) ..
-          ( 97, 47) .. controls ( 94, 47) and ( 93, 47) ..
-          ( 92, 47) -- ( 92, 47) --
-          ( 91, 47) .. controls ( 90, 46) and ( 88, 45) ..
-          ( 88, 45) .. controls ( 88, 45) and ( 88, 45) ..
-          ( 87, 45) .. controls ( 87, 45) and ( 87, 45) ..
-          ( 87, 45) .. controls ( 86, 46) and ( 86, 48) ..
-          ( 86, 49) -- ( 87, 50) --
-          ( 86, 51) .. controls ( 85, 51) and ( 85, 52) ..
-          ( 85, 53) .. controls ( 85, 54) and ( 85, 57) ..
-          ( 85, 58) .. controls ( 85, 58) and ( 85, 58) ..
-          ( 82, 59) .. controls ( 79, 59) and ( 77, 59) ..
-          ( 77, 59) .. controls ( 77, 59) and ( 77, 59) ..
-          ( 78, 59) .. controls ( 80, 59) and ( 83, 59) ..
-          ( 85, 59) .. controls ( 85, 59) and ( 85, 59) ..
-          ( 85, 59) .. controls ( 86, 59) and ( 86, 59) ..
-          ( 86, 59) .. controls ( 86, 59) and ( 85, 59) ..
-          ( 84, 59) .. controls ( 82, 60) and ( 80, 60) ..
-          ( 79, 60) .. controls ( 78, 61) and ( 77, 61) ..
-          ( 77, 61) .. controls ( 77, 61) and ( 78, 61) ..
-          ( 79, 61) .. controls ( 81, 60) and ( 83, 60) ..
-          ( 85, 60) .. controls ( 86, 60) and ( 86, 60) ..
-          ( 86, 60) .. controls ( 86, 60) and ( 87, 61) ..
-          ( 88, 62) .. controls ( 89, 63) and ( 90, 63) ..
-          ( 92, 63) .. controls ( 92, 63) and ( 93, 64) ..
-          ( 93, 64) .. controls ( 93, 64) and ( 93, 64) ..
-          ( 93, 64) .. controls ( 92, 64) and ( 92, 65) ..
-          ( 92, 65) .. controls ( 92, 66) and ( 90, 66) ..
-          ( 89, 66) .. controls ( 88, 66) and ( 88, 66) ..
-          ( 87, 65) .. controls ( 87, 64) and ( 86, 63) ..
-          ( 86, 63) .. controls ( 85, 63) and ( 84, 63) ..
-          ( 84, 63) .. controls ( 84, 63) and ( 84, 63) ..
-          ( 84, 63) .. controls ( 85, 64) and ( 86, 65) ..
-          ( 86, 66) .. controls ( 87, 67) and ( 87, 68) ..
-          ( 88, 68) .. controls ( 89, 68) and ( 89, 68) ..
-          ( 90, 68) -- ( 92, 68) -- ( 92, 70) -- ( 92, 72) --
-          ( 91, 72) .. controls ( 91, 72) and ( 91, 73) ..
-          ( 91, 73) .. controls ( 90, 73) and ( 90, 73) ..
-          ( 91, 73) .. controls ( 92, 73) and ( 92, 73) ..
-          ( 92, 73) .. controls ( 93, 73) and ( 93, 73) ..
-          ( 93, 70) .. controls ( 93, 67) and ( 93, 67) ..
-          ( 94, 66) -- ( 94, 66) --
-          ( 94, 69) .. controls ( 94, 71) and ( 94, 73) ..
-          ( 94, 73) .. controls ( 94, 73) and ( 94, 73) ..
-          ( 93, 74) .. controls ( 93, 74) and ( 93, 74) ..
-          ( 93, 74) .. controls ( 93, 74) and ( 93, 74) ..
-          ( 94, 74) .. controls ( 94, 74) and ( 95, 74) ..
-          ( 96, 73) .. controls ( 96, 72) and ( 96, 71) ..
-          ( 96, 68) -- ( 96, 66) -- ( 96, 66) --
-          ( 96, 69) .. controls ( 96, 72) and ( 96, 72) ..
-          ( 97, 73) .. controls ( 97, 74) and ( 99, 74) ..
-          ( 99, 74) .. controls ( 99, 74) and ( 99, 74) ..
-          ( 99, 73) .. controls ( 99, 73) and ( 98, 73) ..
-          ( 98, 72) .. controls ( 98, 72) and ( 98, 66) ..
-          ( 98, 66) .. controls ( 98, 66) and ( 99, 66) ..
-          ( 99, 66) .. controls ( 99, 67) and ( 99, 67) ..
-          ( 99, 69) .. controls ( 99, 71) and ( 99, 72) ..
-          ( 99, 72) .. controls ( 99, 73) and (100, 73) ..
-          (100, 73) .. controls (101, 73) and (101, 73) ..
-          (101, 73) .. controls (102, 73) and (102, 73) ..
-          (102, 73) .. controls (101, 72) and (101, 72) ..
-          (101, 69) .. controls (101, 66) and (101, 65) ..
-          (100, 65) .. controls (100, 64) and (100, 64) ..
-          (100, 64) -- ( 99, 64) --
-          (100, 63) .. controls (101, 63) and (102, 63) ..
-          (103, 63) .. controls (104, 62) and (106, 61) ..
-          (106, 60) -- (106, 60) --
-          (107, 60) .. controls (109, 60) and (113, 60) ..
-          (115, 61) .. controls (115, 61) and (115, 61) ..
-          (115, 61) .. controls (115, 60) and (111, 60) ..
-          (108, 59) .. controls (107, 59) and (107, 59) ..
-          (107, 59) .. controls (107, 59) and (107, 59) ..
-          (107, 59) -- (107, 59) --
-          (108, 59) .. controls (110, 59) and (112, 59) ..
-          (114, 59) .. controls (115, 59) and (115, 59) ..
-          (115, 59) .. controls (115, 59) and (112, 59) ..
-          (109, 59) .. controls (108, 58) and (107, 58) ..
-          (107, 58) .. controls (107, 58) and (107, 58) ..
-          (107, 58) .. controls (107, 57) and (107, 56) ..
-          (107, 55) .. controls (107, 53) and (107, 53) ..
-          (107, 53) .. controls (107, 52) and (106, 51) ..
-          (106, 50) -- (105, 50) --
-          (105, 48) .. controls (105, 47) and (105, 46) ..
-          (105, 46) -- (105, 45) --
-          (104, 45) .. controls (104, 45) and (104, 45) ..
-          (103, 45) -- cycle;
-      \protect\end{scope}
-    \protect\end{tikzpicture}}
-  ~}
-}{}\par
-
-\ifdefempty{\gitlabsocialsymbol} {
-  \renewcommand*{\gitlabsocialsymbol} {
-    \protect\raisebox{-0.12em}{
-      \protect\begin{tikzpicture}[x=0.11em, y=0.11em, xscale=0.015, yscale=-0.015, inner sep=0pt, outer sep=0pt]
-      \protect\begin{scope}[shift={(507,387)}]
-      \protect\path[fill=gitlab,line width=0.057pt]
-      (105.2000,24.9000) .. controls (102.1000,16.0000) and (89.5000,16.0000) ..
-      (86.3000,24.9000) -- (29.8000,199.7000) -- (161.7000,199.7000) .. controls
-      (161.7000,199.7000) and (105.2000,24.9000) .. (105.2000,24.9000) -- cycle
-      (0.9000,287.7000) .. controls (-1.7000,295.7000) and (1.2000,304.6000) ..
-      (8.0000,309.7000) -- (255.9000,493.7000) -- (29.7000,199.7000) --	cycle
-      (161.7000,199.7000) -- (161.7000,199.7000) -- (256.0000,493.7000) -- (350.3000,199.7000) -- cycle
-      (511.1000,287.7000) -- (482.3000,199.7000) -- (256.0000,493.7000) --
-      (503.9000,309.7000) .. controls (510.8000,304.6000) and (513.6000,295.7000) ..
-      (511.1000,287.7000) -- cycle(425.7000,24.9000) .. controls (422.6000,16.0000)
-      and (410.0000,16.0000) .. (406.8000,24.9000) -- (350.2000,199.7000) -- (482.2000,199.7000) -- cycle;
-      \protect\end{scope}
-      \protect\end{tikzpicture}}
-  ~}
-}{}\par
-
-\ifdefempty{\skypesocialsymbol} {
-  \renewcommand*{\skypesocialsymbol} {
-  \protect\raisebox{-0.15em}{
-    \protect\begin{tikzpicture}[y=0.08em, x=0.08em, xscale=0.020, yscale=-0.020, inner sep=0pt, outer sep=0pt]
-      \protect\begin{scope}[shift={(507,387)}]
-        \protect\path[fill=skype,even odd rule]
-          (487.6550,288.9690) .. controls (489.0610,278.5690) and (489.8700,267.9960) ..
-          (489.8700,257.2330) .. controls (489.8700,128.0770) and (384.5990,23.3610) ..
-          (254.7670,23.3610) .. controls (241.8630,23.3610) and (229.2120,24.4210) ..
-          (216.9010,26.4410) .. controls (194.8280,12.0570) and (168.5590,3.6740) ..
-          (140.2880,3.6740) .. controls (62.7660,3.6740) and (0.0000,66.4820) ..
-          (0.0000,143.9800) .. controls (0.0000,172.1780) and (8.2990,198.3740) ..
-          (22.5900,220.3690) .. controls (20.6650,232.3860) and (19.6810,244.6920) ..
-          (19.6810,257.2290) .. controls (19.6810,386.4050) and (124.8980,491.1100) ..
-          (254.7660,491.1100) .. controls (269.4230,491.1100) and (283.6930,489.6840) ..
-          (297.5620,487.1780) .. controls (319.1120,500.5470) and (344.4960,508.3260) ..
-          (371.7080,508.3260) .. controls (449.2100,508.3260) and (512.0010,445.5020) ..
-          (512.0010,368.0120) .. controls (511.9980,338.7190) and (503.0410,311.4840) ..
-          (487.6550,288.9690) -- cycle(276.7400,429.5960) .. controls (202.0340,433.4870) and (167.0750,416.9590) .. (135.0500,386.9050) .. controls (99.2850,353.3370) and (113.6520,315.0500) ..
-          (142.7900,313.1040) .. controls (171.9120,311.1590) and (189.3980,346.1160) ..
-          (204.9410,355.8400) .. controls (220.4650,365.5280) and (279.5340,387.6000) ..
-          (310.7350,351.9320) .. controls (344.7100,313.1040) and (288.1410,293.0120) ..
-          (246.6760,286.9300) .. controls (187.4730,278.1640) and (112.7260,246.1370) ..
-          (118.5410,183.0230) .. controls (124.3580,119.9490) and (172.1230,87.6090) ..
-          (222.3910,83.0470) .. controls (286.4680,77.2300) and (328.1820,92.7540) ..
-          (361.1760,120.9070) .. controls (399.3270,153.4360) and (378.6840,189.8010) ..
-          (354.3770,192.7270) .. controls (330.1660,195.6360) and (302.9730,139.2230) ..
-          (249.5860,138.3750) .. controls (194.5590,137.5110) and (157.3690,195.6360) ..
-          (225.3000,212.1590) .. controls (293.2660,228.6640) and (366.0500,235.4450) ..
-          (392.2610,297.5760) .. controls (418.4900,359.7130) and (351.5070,425.7010) ..
-          (276.7400,429.5960) -- cycle;
-      \protect\end{scope}
-    \protect\end{tikzpicture}}
-  ~}
-}{}\par
-
-\ifdefempty{\googlescholarsocialsymbol} {
-  \renewcommand*{\googlescholarsocialsymbol} {
-    \protect\raisebox{-0.12em}{
-    \protect\begin{tikzpicture}[y=2.0pt, x=2.0pt, yscale=-0.1, xscale=0.1, inner sep=0pt, outer sep=0pt]
-    \protect\begin{scope}[shift={(507,387)}]
-    \protect\path[fill=googlescholar] (25.0000,2.0000) .. controls (12.3095,2.0000) and (2.0000,12.3095)
-		.. (2.0000,25.0000) .. controls (2.0000,37.6905) and (12.3095,48.0000) ..
-		(25.0000,48.0000) .. controls (37.6905,48.0000) and (48.0000,37.6905) ..
-		(48.0000,25.0000) .. controls (48.0000,12.3095) and (37.6905,2.0000) ..
-		(25.0000,2.0000) -- cycle(25.0000,4.0000) .. controls (36.6095,4.0000) and
-		(46.0000,13.3905) .. (46.0000,25.0000) .. controls (46.0000,36.6095) and
-		(36.6095,46.0000) .. (25.0000,46.0000) .. controls (13.3905,46.0000) and
-		(4.0000,36.6095) .. (4.0000,25.0000) .. controls (4.0000,13.3905) and
-		(13.3905,4.0000) .. (25.0000,4.0000) -- cycle(21.0000,11.0000) --
-		(11.0000,20.0000) -- (17.7812,20.0000) .. controls (17.8012,22.8470) and
-		(19.9675,25.7305) .. (23.7695,25.7305) .. controls (24.1295,25.7305) and
-		(24.5297,25.6904) .. (24.9297,25.6504) .. controls (24.7497,26.1004) and
-		(24.5605,26.4701) .. (24.5605,27.0801) .. controls (24.5605,28.2301) and
-		(25.1404,28.9201) .. (25.6504,29.5801) .. controls (24.0204,29.6901) and
-		(20.9898,29.8795) .. (18.7598,31.2695) .. controls (16.6298,32.5595) and
-		(15.9805,34.4300) .. (15.9805,35.7500) .. controls (15.9805,38.4700) and
-		(18.5005,41.0000) .. (23.7305,41.0000) .. controls (29.9305,41.0000) and
-		(33.2207,37.5105) .. (33.2207,34.0605) .. controls (33.2207,31.5305) and
-		(31.7795,30.2799) .. (30.1895,28.9199) -- (28.9004,27.8906) .. controls
-		(28.5004,27.5706) and (27.9492,27.1203) .. (27.9492,26.3203) .. controls
-		(27.9492,25.5103) and (28.5007,24.9898) .. (28.9707,24.5098) .. controls
-		(30.4807,23.3098) and (32.0000,21.9602) .. (32.0000,19.2402) .. controls
-		(32.0000,18.1972) and (31.7562,17.3484) .. (31.4082,16.6504) --
-		(35.0000,13.5703) -- (35.0000,17.2773) .. controls (34.4050,17.6233) and
-		(34.0000,18.2610) .. (34.0000,19.0000) -- (34.0000,25.0000) .. controls
-		(34.0000,26.1040) and (34.8960,27.0000) .. (36.0000,27.0000) .. controls
-		(37.1040,27.0000) and (38.0000,26.1040) .. (38.0000,25.0000) --
-		(38.0000,19.0000) .. controls (38.0000,18.2620) and (37.5950,17.6243) ..
-		(37.0000,17.2773) -- (37.0000,12.0000) .. controls (37.0000,11.9570) and
-		(36.9806,11.9209) .. (36.9746,11.8789) -- (38.0000,11.0000) --
-		(21.0000,11.0000) -- cycle(24.2695,14.2402) .. controls (27.2695,14.2402) and
-		(28.8203,18.3500) .. (28.8203,21.0000) .. controls (28.8203,21.6500) and
-		(28.7399,22.8199) .. (27.9199,23.6699) .. controls (27.3399,24.2599) and
-		(26.3709,24.6992) .. (25.4609,24.6992) .. controls (22.3709,24.6992) and
-		(20.9492,20.6202) .. (20.9492,18.1602) .. controls (20.9492,17.2102) and
-		(21.1400,16.2209) .. (21.7500,15.4609) .. controls (22.3300,14.7109) and
-		(23.3395,14.2402) .. (24.2695,14.2402) -- cycle(26.0391,30.6094) .. controls
-		(26.4091,30.6094) and (26.5909,30.6104) .. (26.8809,30.6504) .. controls
-		(29.6209,32.6304) and (30.8008,33.6202) .. (30.8008,35.4902) .. controls
-		(30.8008,37.7602) and (28.9700,39.4609) .. (25.5000,39.4609) .. controls
-		(21.6400,39.4609) and (19.1602,37.5905) .. (19.1602,34.9805) .. controls
-		(19.1602,32.3705) and (21.4598,31.4992) .. (22.2598,31.1992) .. controls
-		(23.7698,30.6792) and (25.7191,30.6094) .. (26.0391,30.6094) -- cycle;
-  \protect\end{scope}
-  \protect\end{tikzpicture}}
-~}
-}{}\par
-
 \ifdefempty{\matrixsocialsymbol} {
   \renewcommand*{\matrixsocialsymbol} {
     \protect\raisebox{-0.12em}{
-    \protect\begin{tikzpicture}[y=1.8pt, x=1.8pt, yscale=-0.15, xscale=0.15, inner sep=0pt, outer sep=0pt]
+    \protect\begin{tikzpicture}[y=1.8pt, x=1.8pt, yscale=-0.15, xscale=0.15, inner sep=0pt, outer sep=0pt, trim right=142]
     \protect\begin{scope}[shift={(507,387)}]
     \protect\path[fill=matrix]
       (0.9360,0.7320) .. controls (0.9360,10.9053) and (0.9360,21.0787) ..
@@ -390,7 +87,7 @@
 \ifdefempty{\codebergsocialsymbol} {
   \renewcommand*{\codebergsocialsymbol} {
     \protect\raisebox{-0.12em}{
-    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt]
+    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt, trim right=2792]
     \protect\begin{scope}[shift={(507, 387)}]
       \protect\path[scale=0.265, opacity=0.500, line cap=butt, line join=miter, line width=0.779pt, miter limit=2.00]
       (11249.8942,-1872.9296)arc(269.285:169.240:0.201313 and 0.150) --
@@ -410,7 +107,7 @@
 \ifdefempty{\simplexsocialsymbol} {
   \renewcommand*{\simplexsocialsymbol} {
     \protect\raisebox{-0.12em}{
-    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt]
+    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt, trim right=410]
     \protect\begin{scope}[shift={(507,387)}, rotate=45]
       \protect\path[fill=simplex!80, scale=0.065]
       (0,0) rectangle +(100,20)
@@ -429,7 +126,7 @@
 \ifdefempty{\threemasocialsymbol} {
   \renewcommand*{\threemasocialsymbol} {
     \protect\raisebox{-0.12em}{
-    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt]
+    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt, trim right=408]
     \protect\begin{scope}[shift={(507,387)}]
       \protect\path[fill=threema, scale=0.015]
       % speech bubble

--- a/moderncviconstikz.sty
+++ b/moderncviconstikz.sty
@@ -35,13 +35,20 @@
 %-------------------------------------------------------------------------------
 %                all symbols described in moderncv.cls
 %                only redefine symbols that are not defined at this level
-%                formula for trim right = (shift_x​ + scale * x_min​) * x_scale * x
 %-------------------------------------------------------------------------------
+% this will act as a normalizer to mimic the same behavior as for fontaewesome icons
+\DeclareRobustCommand{\@tikzsocialicon}[1]{%
+  \mbox{\raisebox{-0.12em}{#1}}%
+}%
+
 \ifdefempty{\matrixsocialsymbol} {
   \renewcommand*{\matrixsocialsymbol} {
-    \protect\raisebox{-0.12em}{
-    \protect\begin{tikzpicture}[y=1.8pt, x=1.8pt, yscale=-0.15, xscale=0.15, inner sep=0pt, outer sep=0pt, trim right=142]
+    \@tikzsocialicon{%
+    \protect\begin{tikzpicture}[y=1.8pt, x=1.8pt, yscale=-0.15, xscale=0.15, inner sep=0pt, outer sep=0pt]
     \protect\begin{scope}[shift={(507,387)}]
+    % path can be overridden, but defines a tight bounding box
+    \protect\path[use as bounding box]
+      (0.0950, -0.1013) rectangle (30.9390, 32.9750);
     \protect\path[fill=matrix]
       (0.9360,0.7320) .. controls (0.9360,10.9053) and (0.9360,21.0787) ..
       (0.9360,31.2520) .. controls (1.6673,31.2520) and (2.3987,31.2520) ..
@@ -81,14 +88,17 @@
       (29.2278,31.2454) and (29.6629,31.2462) .. (30.0980,31.2470) -- cycle;
     \protect\end{scope}
     \protect\end{tikzpicture}}
-  ~}
+  }
 }{}\par
 
 \ifdefempty{\codebergsocialsymbol} {
   \renewcommand*{\codebergsocialsymbol} {
-    \protect\raisebox{-0.12em}{
-    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt, trim right=2792]
+    \@tikzsocialicon{
+    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt]
     \protect\begin{scope}[shift={(507, 387)}]
+      % path can be overridden, but defines a tight bounding box
+      \protect\path[use as bounding box, scale=0.265]
+      (11236.4, -1884) rectangle (11273, -1848);
       \protect\path[scale=0.265, opacity=0.500, line cap=butt, line join=miter, line width=0.779pt, miter limit=2.00]
       (11249.8942,-1872.9296)arc(269.285:169.240:0.201313 and 0.150) --
       (11258.5852,-1839.4433)arc(66.699:32.084:23.067) --
@@ -101,14 +111,18 @@
       -- cycle;
     \protect\end{scope}
     \protect\end{tikzpicture}}
-  ~}
+  }
 }{}\par
 
 \ifdefempty{\simplexsocialsymbol} {
   \renewcommand*{\simplexsocialsymbol} {
-    \protect\raisebox{-0.12em}{
-    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt, trim right=410]
+    \@tikzsocialicon{%
+    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt]
     \protect\begin{scope}[shift={(507,387)}, rotate=45]
+      % path can be overridden, but defines a tight bounding box
+      \protect\path[use as bounding box, scale=0.065]
+      (0, -100) rectangle (160, 60);
+
       \protect\path[fill=simplex!80, scale=0.065]
       (0,0) rectangle +(100,20)
       (40,-60) rectangle +(20,120);
@@ -120,14 +134,18 @@
       (100,0) rectangle +(60,20);
     \protect\end{scope}
     \protect\end{tikzpicture}}
-  ~}
+  }
 }{}\par
 
 \ifdefempty{\threemasocialsymbol} {
   \renewcommand*{\threemasocialsymbol} {
-    \protect\raisebox{-0.12em}{
-    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt, trim right=408]
+    \@tikzsocialicon{%
+    \protect\begin{tikzpicture}[y=0.8pt, x=0.8pt, yscale=-1.0, xscale=1.0, inner sep=0pt, outer sep=0pt]
     \protect\begin{scope}[shift={(507,387)}]
+      % path can be overridden, but defines a tight bounding box
+      \protect\path[use as bounding box, scale=0.015]
+      (-263, -325) rectangle (537, 621);
+
       \protect\path[fill=threema, scale=0.015]
       % speech bubble
       (137,25) ellipse (400 and 350)
@@ -148,7 +166,7 @@
       (390,553) circle (68);
     \protect\end{scope}
     \protect\end{tikzpicture}}
-  ~}
+  }
 }{}\par
 
 \endinput


### PR DESCRIPTION
Due to scaling and shifting the bounding box of the `tikz` icons are off compared to other icons.

This PR tries to compensate this horizontal space with `trim right` option and removes too much whitespace.

I also removed not used `tikz` icons as they are already provided by `fontawesome` and I also made use of `googlescholar` `fontawesome` icon as well. 

This will close #259.