### PR TITLE
fix contemporary - reinsert first and last name into letter-header

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ version next
 - Adding optional \postscript{PS text} command to cover letter in all current styles (#271)
 - Decreasing the size of born symbol to "tiny" and raising it by .5ex,
   to look typograpically more in line with born symbols outside moderncv (#273)
+- Fix missing Senders Name in Header (#278)
 
 version 2.5.1 (31 Jan 2026)
 - Fix french babel breaking contemporary style (#219)

--- a/moderncvheadvii.sty
+++ b/moderncvheadvii.sty
@@ -194,6 +194,7 @@
       \addressfont\color{headtext}%
       \if@left\begin{tabular}[b]{@{}r@{}}\fi%
       \if@right\begin{tabular}[b]{@{}l@{}}\fi%
+        {\bfseries\upshape\@firstname~\@lastname}\@firstdetailselementfalse%
         \ifthenelse{\isundefined{\@addressstreet}}{}{\makenewline\addresssymbol\@addressstreet%
           \ifthenelse{\equal{\@addresscity}{}}{}{\makenewline\@addresscity}% if \addresstreet is defined, \addresscity and addresscountry will always be defined but could be empty
           \ifthenelse{\equal{\@addresscountry}{}}{}{\makenewline\@addresscountry}}%
@@ -215,7 +216,7 @@
   \end{tikzpicture}%
 
   \hfill
-  \llap{\usebox{\makeletterdetailsbox}}% \llap is used to suppress 
+  \llap{\usebox{\makeletterdetailsbox}}% \llap is used to suppress
   \\[.15em]%
   \tikzmark{letter-head-end}\\[.15em]%
 


### PR DESCRIPTION
First and Surname does not appear in the Letter Header.
This PR resolves that issue.

Details are described in #278 