### PR TITLE
New Header option in contemporary style (separator)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ version next
 - Fix missing Senders Name in Header (#278)
 - Document an additional example in the userguide on how to adjust the skill matrix (#213)
 - Adds contributing guidelines for moderncv (#275)
+- New Contemporary style option - separator under the CV header can be shown or hidden (#280)
 
 
 version 2.5.1 (31 Jan 2026)

--- a/manual/moderncv_userguide.tex
+++ b/manual/moderncv_userguide.tex
@@ -716,7 +716,9 @@ This style allows the following options which \emph{only} affect header and foot
   \textbf{\code{data in head}} & values: \code{details} (default), \code{nodetails}.
   Toggles between the header and footer as the location of personal data on the page. \\
   \textbf{\code{qr}}      & values: \code{qr} (default), \code{noqr}.
-  Enables or disables the inclusion of a QR code of your personal website.
+  Enables or disables the inclusion of a QR code of your personal website. \\
+  \textbf{\code{separator in head}}      & values: \code{separator} (default), \code{noseparator}.
+  Shows or hides the separator line after the colored header.
 \end{tabular}
 \note For the \code{contemporary} style it is recommended to use the \code{\\moderncvcolor\{cerulean\}} color scheme. The \code{contemporary} style is even more appealing with reduced margins. Use this in your preamble:
 \begin{lstlisting}

--- a/moderncvheadvii.sty
+++ b/moderncvheadvii.sty
@@ -29,8 +29,13 @@
 \@initializeif{\if@right}\@rightfalse
 \DeclareOption{right}   {\@leftfalse\@righttrue}
 
+% separator line option: "separator" (default) or "noseparator"
+\@initializeif{\if@separator}\@separatortrue
+\DeclareOption{separator}   {\@separatortrue}
+\DeclareOption{noseparator} {\@separatorfalse}
+
 \DeclareOption*{}% avoid choking on unknown options
-\ExecuteOptions{details,qr,left}
+\ExecuteOptions{details,qr,left,separator}
 \ProcessOptions*\relax% \ProcessOptions* processes the options in the order provided (i.e., with the later ones possibly overriding the former ones), while \ProcessOptions processes them in the order of the package
 
 
@@ -148,10 +153,10 @@
 
     % case with no photo: assure defined \@photoframewidth with 2pt
     \ifthenelse{\isundefined{\@photo}}{\@initializelength{\@photoframewidth}\setlength{\@photoframewidth}{2pt}}{}%
-    \path[draw,line width=\@photoframewidth]
-        (head-bg.south west) edge[color=headhr!85!black] ([xshift=8em]head-bg.south west)
-        ([xshift=8em]head-bg.south west) edge[color=headhr] ([xshift=-8em]head-bg.south east)
-        ([xshift=-8em]head-bg.south east) edge[color=headhr!85!black] (head-bg.south east);
+    \if@separator%
+        \path[draw,line width=\@photoframewidth, color=headhr!85!black]
+            (head-bg.south west) -- (head-bg.south east);
+    \fi%
   \end{tikzpicture}%
   \if@left%
     \usebox{\makecvheadpicturebox}%

--- a/moderncvstylecontemporary.sty
+++ b/moderncvstylecontemporary.sty
@@ -19,6 +19,8 @@
 \DeclareOption{right}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,right}}
 \DeclareOption{qr}  {\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,qr}}
 \DeclareOption{noqr}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,noqr}}
+\DeclareOption{separator}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,separator}}
+\DeclareOption{noseparator}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,noseparator}}
 
 \DeclareOption*{}% avoid choking on unknown options
 \ExecuteOptions{left,qr}


### PR DESCRIPTION
As discussed in #280, this PR now delivers the following:

---
> Thanks, [@jalopezg-git](https://github.com/jalopezg-git) for still having an eye on the project here, I appreciate your answer!
> 
> I think that helps already to better understand the issue here. Personally I liked the idea to have a kind of colored separator line after the _moderncvhead_.
> 
> For me it seems more a matter of taste, which is usually not so easy to answer. Therefore I would vote for your suggested compromise and add a new option, which includes your changes, [@Markus-Be](https://github.com/Markus-Be). Thank you btw to directly jump into action with another PR.
> 
> This would mean, that we need:
> 
>     * new option for contemporary style (maybe keep the previous behaviour as default)
> 
>     * both variants: colored border (single color is also fine for me) and without the separator
> 
>     * a description in the **user guide**
> 
>     * a `CHANGELOG` entry
> 
> 
> If you want to work on that, [@Markus-Be](https://github.com/Markus-Be) , I will be very happy, otherwise I can also have a closer look into the PR and add the option for a final PR.

see https://github.com/moderncv/moderncv/issues/280#issuecomment-4445626495