### PR TITLE
Fix #286: Broken phone symbols.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ version next
 - Fix missing Senders Name in Header (#278)
 - Document an additional example in the userguide on how to adjust the skill matrix (#213)
 - Adds contributing guidelines for moderncv (#275)
+- Fix incomplete social icons migration (Fontawesome 6) (#287)
 
 
 version 2.5.1 (31 Jan 2026)

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -68,16 +68,16 @@
 
 
 %\renewcommand*{\addresssymbol}            {}
-\renewcommand*{\mobilephonesymbol}        {{\color{mobilephone}\small\faMobile*}~}            % alternative: \faMobile (solid style)
-\renewcommand*{\fixedphonesymbol}         {{\color{fixedphone}\small\faPhone*}~}             % alternative: \faPhone (reversed)
+\renewcommand*{\mobilephonesymbol}        {{\color{mobilephone}\small\faMobileScreen}~}            % alternative: \faMobile (solid style)
+\renewcommand*{\fixedphonesymbol}         {{\color{fixedphone}\small\faPhone}~}             % alternative: \faPhoneFlip (reversed)
 \renewcommand*{\faxphonesymbol}           {{\color{faxphone}\small\faFax}~}                % alternative: \faPrint
 \renewcommand*{\emailsymbol}              {{\color{email}\small\faEnvelope[regular]}~}  % alternative: \faInbox, \faEnvelope (solid style)
-\renewcommand*{\homepagesymbol}           {{\color{homepage}\small\faEarthAmericas}~}      % alternative: \faHome, \faGlobe, \faEarthEurope, \faEarthAfrica, \faEarthAsia, \faEarthOceania
+\renewcommand*{\homepagesymbol}           {{\color{homepage}\small\faEarthAmericas}~}      % alternative: \faHouse, \faHouseChimney, \faGlobe, \faEarthEurope, \faEarthAfrica, \faEarthAsia, \faEarthOceania
 \renewcommand*{\linkedinsocialsymbol}     {{\color{linkedin}\small\faLinkedinIn}~}         % alternative: \faLinkedin
-\renewcommand*{\xingsocialsymbol}         {{\color{xing}\small\faXing}~}               % alternative: \faXingSquare
-\renewcommand*{\twittersocialsymbol}      {{\color{twitter}\small\faTwitter}~}            % alternative: \faTwitterSquare
+\renewcommand*{\xingsocialsymbol}         {{\color{xing}\small\faXing}~}               % alternative: \faSquareXing
+\renewcommand*{\twittersocialsymbol}      {{\color{twitter}\small\faTwitter}~}            % alternative: \faSquareTwitter, \faXTwitter, \faSquareXTwitter
 \renewcommand*{\mastodonsocialsymbol}     {{\color{mastodon}\small\faMastodon}~}
-\renewcommand*{\githubsocialsymbol}       {{\color{github}\small\faGithub}~}             % alternative: \faGithubSquare, \faGithub*
+\renewcommand*{\githubsocialsymbol}       {{\color{github}\small\faGithub}~}             % alternative: \faSquareGithub, \faGithubAlt
 \renewcommand*{\gitlabsocialsymbol}       {{\color{gitlab}\small\faGitlab}~}
 \renewcommand*{\stackoverflowsocialsymbol}{{\color{stackoverflow}\small\faStackOverflow}~}
 \renewcommand*{\bitbucketsocialsymbol}    {{\color{bitbucket}\small\faBitbucket}~}


### PR DESCRIPTION
Fixes bug #286 by replacing the incorrect macro calls with the correct ones for the fontawesome6 package.