### PR TITLE
Fix tabular parser conflicts in banking style (Remove arydshln dependency)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,8 @@ version next
 - Document an additional example in the userguide on how to adjust the skill matrix (#213)
 - Adds contributing guidelines for moderncv (#275)
 - Fix incomplete social icons migration (Fontawesome 6) (#287)
-
+- Remove arydshln dependency to fix tabular parser conflicts with cventry (#288, #289)
+- Fix further missing Fontawesome 6 icons (\faAsterisk, \faTiktok)
 
 version 2.5.1 (31 Jan 2026)
 - Fix french babel breaking contemporary style (#219)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,7 +12,6 @@ version next
 - Complete the color and style listings in the documentation (#291)
 - Correct additional link signatures in the documentation (#293)
 - Remove arydshln dependency to fix tabular parser conflicts with cventry (#288, #289)
-- Fix further missing Fontawesome 6 icons (\faAsterisk, \faTiktok)
 
 
 version 2.5.1 (31 Jan 2026)

--- a/manual/moderncv_userguide.tex
+++ b/manual/moderncv_userguide.tex
@@ -1108,7 +1108,7 @@ In addition to the packages that \Moderncv provides, the following packages are 
     \item \code{ebgaramond}
     \item \code{kurier}
     \item \code{multirow}
-    \item \code{arydshln}
+
   \end{multicols}
 \end{itemize}
 

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -91,7 +91,7 @@
 \renewcommand*{\discordsocialsymbol}      {{\color{discord}\small\faDiscord}~}
 \renewcommand*{\twitchsocialsymbol}       {{\color{twitch}\small\faTwitch}~}
 \renewcommand*{\youtubesocialsymbol}      {{\color{youtube}\small\faYoutube}~}
-\renewcommand*{\tiktoksocialsymbol}       {{\color{tiktok}\small\faIcon{tiktok}}~}
+\renewcommand*{\tiktoksocialsymbol}       {{\color{tiktok}\small\faTiktok}~}
 \renewcommand*{\instagramsocialsymbol}    {{\color{instagram}\small\faInstagram}~}
 \renewcommand*{\soundcloudsocialsymbol}   {{\color{soundcloud}\small\faSoundcloud}~}
 \renewcommand*{\steamsocialsymbol}        {{\color{steam}\small\faSteam}~}
@@ -102,7 +102,7 @@
 %\renewcommand*{\matrixsocialsymbol}       {}
 % \renewcommand*{\arxivsocialsymbol}        {{\color{arxiv}{\small\faarXiv}}~}
 % \renewcommand*{\inspiresocialsymbol}      {{\color{inspire}{\small\faInspire}}~}
-\renewcommand*{\bornsymbol}               {{\color{born}\raisebox{.5ex}{\tiny\faIcon{asterisk}}}~}           % alternative: \faBabyCarriage
+\renewcommand*{\bornsymbol}               {{\color{born}\raisebox{.5ex}{\tiny\faAsterisk}}~}           % alternative: \faBabyCarriage
 \renewcommand*{\mediumsocialsymbol}     {{\color{medium}\small\faMedium}~}
 
 

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -91,7 +91,7 @@
 \renewcommand*{\discordsocialsymbol}      {{\color{discord}\small\faDiscord}~}
 \renewcommand*{\twitchsocialsymbol}       {{\color{twitch}\small\faTwitch}~}
 \renewcommand*{\youtubesocialsymbol}      {{\color{youtube}\small\faYoutube}~}
-\renewcommand*{\tiktoksocialsymbol}       {{\color{tiktok}\small\faTiktok}~}
+\renewcommand*{\tiktoksocialsymbol}       {{\color{tiktok}\small\faIcon{tiktok}}~}
 \renewcommand*{\instagramsocialsymbol}    {{\color{instagram}\small\faInstagram}~}
 \renewcommand*{\soundcloudsocialsymbol}   {{\color{soundcloud}\small\faSoundcloud}~}
 \renewcommand*{\steamsocialsymbol}        {{\color{steam}\small\faSteam}~}
@@ -102,7 +102,7 @@
 %\renewcommand*{\matrixsocialsymbol}       {}
 % \renewcommand*{\arxivsocialsymbol}        {{\color{arxiv}{\small\faarXiv}}~}
 % \renewcommand*{\inspiresocialsymbol}      {{\color{inspire}{\small\faInspire}}~}
-\renewcommand*{\bornsymbol}               {{\color{born}\raisebox{.5ex}{\tiny\faAsterisk}}~}           % alternative: \faBabyCarriage
+\renewcommand*{\bornsymbol}               {{\color{born}\raisebox{.5ex}{\tiny\faIcon{asterisk}}}~}           % alternative: \faBabyCarriage
 \renewcommand*{\mediumsocialsymbol}     {{\color{medium}\small\faMedium}~}
 
 

--- a/moderncvskillmatrix.sty
+++ b/moderncvskillmatrix.sty
@@ -233,11 +233,11 @@
 \usetikzlibrary{babel}
 \RequirePackage{multirow}
 % package arydshln is needed for the dashed lines but is incompatible with fancy style
-\if@moderncvbodyv%
-%     \RequirePackage{arydshln} % incompatible with fancy style
-\else%
-    \RequirePackage{arydshln} % incompatible with fancy style
-\fi
+% \if@moderncvbodyv%
+% %     \RequirePackage{arydshln} % incompatible with fancy style
+% \else%
+%     % \RequirePackage{arydshln} % incompatible with fancy style
+% \fi
 
 % %-------------------------------------------------------------------------------
 % %                \cvskill command
@@ -613,9 +613,9 @@
             \setlength{\cvskilllegend@rightdescriptorwidth}{\skilllegend@bodylength-\skilllegend@leftdesriptorfactor\skilllegend@bodylength-\cvskill@width-\skillmatrix@padding-3\skilllegend@padding}%
             \begin{tabular}{@{}p{\skilllegend@hintscolumnwidth}%
                             @{\hspace{\separatorcolumnwidth}}%
-                            p{\cvskill@width}@{\hspace{\skilllegend@padding}};{.6pt/1pt}%%
+                            p{\cvskill@width}@{\hspace{\skilllegend@padding}}!{\color{bodyrulecolor}\vrule width 0.6pt}%%
                             p{2\skilllegend@padding}p{\cvskilllegend@leftdescriptorwidth}@{}@{\hspace{2\skillmatrix@padding}}%
-                            p{\cvskill@width}@{\hspace{\skilllegend@padding}};{.6pt/1pt}%
+                            p{\cvskill@width}@{\hspace{\skilllegend@padding}}!{\color{bodyrulecolor}\vrule width 0.6pt}%
                             p{2\skilllegend@padding}%
                             p{\cvskilllegend@rightdescriptorwidth}@{}}%
                 \raggedleft\hintstyle{#8}  & \cvskill{1}& & {\skillLegend@FontSize #3} & \cvskill{3}& &{\skillLegend@FontSize #5 } \\%
@@ -663,10 +663,10 @@
                 \setlength{\cvskilllegend@rightdescriptorwidth}{\skilllegend@bodylength-\skilllegend@leftdesriptorfactor\skilllegend@bodylength-\cvskill@width-\skillmatrix@padding-4\skilllegend@padding}%
                 \arrayrulecolor{bodyrulecolor}
                 \begin{tabular}{@{}p{\skilllegend@hintscolumnwidth}
-                                @{\hspace{\separatorcolumnwidth}}p{\cvskill@width}@{\hspace{\skilllegend@padding}};{.6pt/1pt}%
+                                @{\hspace{\separatorcolumnwidth}}p{\cvskill@width}@{\hspace{\skilllegend@padding}}!{\color{bodyrulecolor}\vrule width 0.6pt}%
                                 p{2\skilllegend@padding}%
                                 p{\cvskilllegend@leftdescriptorwidth}@{\hspace{\skillmatrix@padding}}%
-                                p{\cvskill@width}@{\hspace{\skilllegend@padding}};{.6pt/1pt}%
+                                p{\cvskill@width}@{\hspace{\skilllegend@padding}}!{\color{bodyrulecolor}\vrule width 0.6pt}%
                                 p{2\skilllegend@padding}p{\cvskilllegend@rightdescriptorwidth}@{}}%
                     \raggedleft\hintstyle{}  & \cvskill{1} & & {\skillLegend@FontSize #3} & \cvskill{3} & & {\skillLegend@FontSize #5 } \\
                                 %
@@ -783,9 +783,9 @@
             \setlength{\cvskilllegend@rightdescriptorwidth}{\skilllegend@bodylength-\skilllegend@leftdesriptorfactor\skilllegend@bodylength-\cvskill@width-\skillmatrix@padding-3\skilllegend@padding}%
             \begin{tabular}{@{}p{\skilllegend@hintscolumnwidth}%
                             @{\hspace{\separatorcolumnwidth}}%
-                            p{\cvskill@width}@{\hspace{\skilllegend@padding}};{.6pt/1pt}%%
+                            p{\cvskill@width}@{\hspace{\skilllegend@padding}}!{\color{bodyrulecolor}\vrule width 0.6pt}%%
                             p{2\skilllegend@padding}p{\cvskilllegend@leftdescriptorwidth}@{}@{\hspace{2\skillmatrix@padding}}%
-                            p{\cvskill@width}@{\hspace{\skilllegend@padding}};{.6pt/1pt}%
+                            p{\cvskill@width}@{\hspace{\skilllegend@padding}}!{\color{bodyrulecolor}\vrule width 0.6pt}%
                             p{2\skilllegend@padding}%
                             p{\cvskilllegend@rightdescriptorwidth}@{}}%
                 \raggedleft\hintstyle{#8}  & \cvskill{1}& & {\skillLegend@FontSize #3} & \cvskill{4}& &{\skillLegend@FontSize #6} \\%
@@ -831,10 +831,10 @@
                 \setlength{\cvskilllegend@leftdescriptorwidth}{\skilllegend@leftdesriptorfactor\skilllegend@bodylength-\cvskill@width-\skillmatrix@padding-6\skilllegend@padding}%
                 \setlength{\cvskilllegend@rightdescriptorwidth}{\skilllegend@bodylength-\skilllegend@leftdesriptorfactor\skilllegend@bodylength-\cvskill@width-\skillmatrix@padding-6\skilllegend@padding}%
                 \begin{tabular}{@{}p{\skilllegend@hintscolumnwidth}
-                                @{\hspace{\separatorcolumnwidth}}p{\cvskill@width}@{\hspace{\skilllegend@padding}};{.6pt/1pt}%
+                                @{\hspace{\separatorcolumnwidth}}p{\cvskill@width}@{\hspace{\skilllegend@padding}}!{\color{bodyrulecolor}\vrule width 0.6pt}%
                                 p{2\skilllegend@padding}%
                                 p{\cvskilllegend@leftdescriptorwidth}@{\hspace{2\skillmatrix@padding}}%
-                                p{\cvskill@width}@{\hspace{\skilllegend@padding}};{.6pt/1pt}%
+                                p{\cvskill@width}@{\hspace{\skilllegend@padding}}!{\color{bodyrulecolor}\vrule width 0.6pt}%
                                 p{2\skilllegend@padding}p{\cvskilllegend@rightdescriptorwidth}@{}}%
                     \raggedleft\hintstyle{} & \cvskill{1} & & {\skillLegend@FontSize#3} & \cvskill{4} & & {\skillLegend@FontSize#6}\\%
                                 %
@@ -1007,7 +1007,7 @@
                     p{\cvskill@descriptorwidth}@{\hspace{\skillmatrix@padding}}%
                     p{\cvskill@experiencewidth} @{\hspace{\skillmatrix@padding}}%
                     p{\skillmatrix@commentwidth}@{}}%
-                \cdashline{2-5}[.6pt/1pt]
+                \noalign{\vspace{2pt}\noindent\tikz \draw[dashed, color=bodyrulecolor, line width=0.6pt] (0,0) -- (\linewidth,0);\vspace{2pt}}
                 \raggedleft\hintstyle{#3} &\centering \cvskill{#4} &\centering {#5} & \centering {#6} &{\itshape#7}%
             \end{tabular}%
         \endgroup

--- a/moderncvskillmatrix.sty
+++ b/moderncvskillmatrix.sty
@@ -232,12 +232,7 @@
 \RequirePackage{tikz}
 \usetikzlibrary{babel}
 \RequirePackage{multirow}
-% package arydshln is needed for the dashed lines but is incompatible with fancy style
-% \if@moderncvbodyv%
-% %     \RequirePackage{arydshln} % incompatible with fancy style
-% \else%
-%     % \RequirePackage{arydshln} % incompatible with fancy style
-% \fi
+
 
 % %-------------------------------------------------------------------------------
 % %                \cvskill command


### PR DESCRIPTION
This PR addresses Issues #288 and #289, and patches a leftover bug from #287.

* **Removed `arydshln` dependency**: The package was conflicting with the banking style's `tabular*` parser (`\cventry`).
* **Replaced `\cdashline`**: Used a native `tikz` dashed line in `moderncvskillmatrix.sty` to maintain identical visual output without the dependency.
* **Fixed FontAwesome 6 Migration**: Updated missed macros (`\faAsterisk` -> `\faIcon{asterisk}` and `\faTiktok` -> `\faIcon{tiktok}`) that were causing `! Undefined control sequence` compilation errors.
* **Updated Documentation**: Removed `arydshln` from the `moderncv_userguide.tex` dependencies list and updated the `CHANGELOG`.
