### PR TITLE
docs: Complete the color and style listings in the documentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ version next
 - Document an additional example in the userguide on how to adjust the skill matrix (#213)
 - Adds contributing guidelines for moderncv (#275)
 - Fix incomplete social icons migration (Fontawesome 6) (#287)
+- Complete the color and style listings in the documentation (#291)
 
 
 version 2.5.1 (31 Jan 2026)

--- a/manual/moderncv_userguide.tex
+++ b/manual/moderncv_userguide.tex
@@ -140,6 +140,7 @@
 \definecolor{cvburgundy}{rgb}{0.596078, 0, 0}   % burgundy: 139/255 (0.545098) or 152/255 (0.596078)
 \definecolor{cvgrey}{rgb}{0.55, 0.55, 0.55}
 \definecolor{cvpurple}{rgb}{0.50, 0.33, 0.80}
+\definecolor{cvcerulean}{HTML}{0081a7}
 
 % Macros
 \newcommand{\todo}[1]{\marginpar{\raggedright \textcolor{red}{[\textbf{TODO:} #1]}}}
@@ -247,10 +248,9 @@ Choose a \Moderncv style and color by adjusting the commands (command order is i
 \end{lstlisting}
 As explained in \cvtemplate, the possible values are
 
-\begin{tabular}{r@{\hspace{2ex}}p{0.65\textwidth}}
-  \textbf{\code{color}:} & \code{black} \cvdoccolorbox{black}, \code{blue} \cvdoccolorbox{cvblue} (default), \code{burgundy} \cvdoccolorbox{cvburgundy}, \code{green} \cvdoccolorbox{cvgreen}, \code{grey} \cvdoccolorbox{cvgrey}, \code{orange} \cvdoccolorbox{cvorange}, \code{purple} \cvdoccolorbox{cvpurple}, \code{red} \cvdoccolorbox{cvred}\\
-  \textbf{\code{style}:} & \code{casual} (default), \code{classic}, \code{banking}, \code{oldstyle},
-  \code{fancy}
+\begin{tabular}{r@{\hspace{2ex}}p{0.72\textwidth}}
+  \textbf{\code{color}:} & \code{black} \cvdoccolorbox{black}, \code{blue} \cvdoccolorbox{cvblue} (default), \code{burgundy} \cvdoccolorbox{cvburgundy}, \code{cerulean} \cvdoccolorbox{cvcerulean}, \code{green} \cvdoccolorbox{cvgreen}, \code{grey} \cvdoccolorbox{cvgrey}, \code{orange} \cvdoccolorbox{cvorange}, \code{purple} \cvdoccolorbox{cvpurple}, \code{red} \cvdoccolorbox{cvred}\\
+  \textbf{\code{style}:} & \code{casual} (default), \code{classic}, \code{banking}, \code{oldstyle}, \code{fancy}, \code{contemporary}
 \end{tabular}
 
 \note Some of the styles take additional options to fine-tune their appearance.


### PR DESCRIPTION
Update the [User Guide], addressing #291:
- Define the `cvcerulean` color in the preamble, following its definition in `moderncvcolors.sty`.
- Add `cerulean` and `contemporary` to the color and style table on page 3.
- Adjust the table width to accommodate for the additions, avoiding weird line breaks.
- Update `CHANGELOG` with a summary of the changes and a reference to the issue they close.

[User Guide]:
  https://github.com/moderncv/moderncv/blob/master/manual/moderncv_userguide.pdf