### PR TITLE
fix: Allow the customisation of the `contemporary` style

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+version next
+- Allow the customisation of the contemporary style (#297)
+
+
 version 2.6.0 (19 Jun 2026)
 - Upgrade to Fontawesome 6 (#183)
 - Document how to set custom strings for social command (#239)

--- a/moderncvstylecontemporary.sty
+++ b/moderncvstylecontemporary.sty
@@ -47,8 +47,23 @@
 %-------------------------------------------------------------------------------
 %               Colors
 %-------------------------------------------------------------------------------
-% skillmatrix
+% head and footer
+\colorlet{lastnamecolor}{color2}
+\colorlet{namecolor}{lastnamecolor}
+\colorlet{headrulecolor}{lastnamecolor!50}
+\colorlet{firstnamecolor}{lastnamecolor!50}
+\colorlet{titlecolor}{color2}
+\colorlet{addresscolor}{color2}
+\colorlet{quotecolor}{color1}
+\colorlet{pictureframecolor}{color1}
+% body
 \colorlet{bodyrulecolor}{color1}
+\colorlet{sectioncolor}{color1}
+\colorlet{subsectioncolor}{color1}
+\colorlet{hintstylecolor}{color0}
+% letter
+\colorlet{letterclosingcolor}{color2}
+% skillmatrix
 \colorlet{skillmatrixfullcolor}{color1}
 \colorlet{skillmatrixemptycolor}{color2!30}
 


### PR DESCRIPTION
Address #297:
- Add the colour definitions required by generic header, body, and footer variants to `moderncvstylecontemporary.sty`, enabling style customisation via `\moderncvhead`, `\moderncvbody`, and `\moderncvfoot`.
- Colour definitions follow those in the `empty`, `casual`, `classic`, and `oldstyle` styles.
- Update `CHANGELOG` with a summary of the changes and a reference to the issue they close.