### PR TITLE
fix: Correct style option defaults

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+version next
+- Correct the documented style option defaults, changing them from nodetails to
+  details for the classic, banking, oldstyle, and fancy styles, to match the
+  current implementation (#299)
+- Set the details option explicitly as default in the banking style (#299)
+- Add the missing details and nodetails options to the contemporary style,
+  setting details and separator as explicit defaults (#299)
+
+
 version 2.6.0 (19 Jun 2026)
 - Upgrade to Fontawesome 6 (#183)
 - Document how to set custom strings for social command (#239)

--- a/manual/moderncv_userguide.tex
+++ b/manual/moderncv_userguide.tex
@@ -662,7 +662,7 @@ This style allows the following options which \emph{only} affect header and foot
 \begin{tabular}{r@{\hspace{2ex}}p{0.75\textwidth}}
   \textbf{\code{alignment}}    & values: \code{left} (default), \code{right}.
   Aligns the address block and the picture. \\
-  \textbf{\code{data in head}} & values: \code{details}, \code{nodetails} (default).
+  \textbf{\code{data in head}} & values: \code{details} (default), \code{nodetails}.
   Toggles between the header and footer as the location of personal data on the page. \\
   \textbf{\code{symbols}}      & values: \code{symbols} (default), \code{nosymbols}.
   Toggles between inclusion of icons or text-based abbreviations for personal data.
@@ -676,7 +676,7 @@ This style allows the following options:
   Aligns the entries in the style. \\
   \textbf{\code{rule style}}       & values: \code{fullrules}, \code{shortrules}, \code{mixedrules} (default), \code{norules}.
   Adjusts the rules used in the style. \\
-  \textbf{\code{data in head}}     & values: \code{details}, \code{nodetails} (default).
+  \textbf{\code{data in head}}     & values: \code{details} (default), \code{nodetails}.
   Toggles between the header and footer as the location of personal data on the page. \\
   \textbf{\code{symbols}}          & values: \code{symbols} (default), \code{nosymbols}.
   Toggles between inclusion of icons or text-based abbreviations for personal data.
@@ -686,7 +686,7 @@ This style allows the following options:
 This style allows the following options:
 
 \begin{tabular}{r@{\hspace{2ex}}p{0.73\textwidth}}
-  \textbf{\code{data in head}} & values: \code{details}, \code{nodetails} (default).
+  \textbf{\code{data in head}} & values: \code{details} (default), \code{nodetails}.
   Toggles between the header and footer as the location of personal data on the page. \\
   \textbf{\code{symbols}}      & values: \code{symbols} (default), \code{nosymbols}.
   Toggles between inclusion of icons or text-based abbreviations for personal data.
@@ -696,7 +696,7 @@ This style allows the following options:
 This style allows the following options:
 
 \begin{tabular}{r@{\hspace{2ex}}p{0.73\textwidth}}
-  \textbf{\code{data in head}} & values: \code{details}, \code{nodetails} (default).
+  \textbf{\code{data in head}} & values: \code{details} (default), \code{nodetails}.
   Toggles between the header and footer as the location of personal data on the page. \\
   \textbf{\code{symbols}}      & values: \code{symbols} (default), \code{nosymbols}.
   Toggles between inclusion of icons or text-based abbreviations for personal data.

--- a/moderncvstylebanking.sty
+++ b/moderncvstylebanking.sty
@@ -36,7 +36,7 @@
 \DeclareOption{nosymbols}    {\@symbolsfalse}
 
 \DeclareOption*{}% avoid choking on unknown options
-\ExecuteOptions{mixedrules,left,symbols}
+\ExecuteOptions{mixedrules,left,symbols,details}
 \ProcessOptions*\relax% \ProcessOptions* processes the options in the order provided (i.e., with the later ones possibly overriding the former ones), while \ProcessOptions processes them in the order of the package
 
 

--- a/moderncvstylecontemporary.sty
+++ b/moderncvstylecontemporary.sty
@@ -17,13 +17,18 @@
 \@initializecommand{\moderncvstyleheadoptions}{}
 \DeclareOption{left} {\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,left}}
 \DeclareOption{right}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,right}}
+% QR code options: "qr" (default) or "noqr"
 \DeclareOption{qr}  {\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,qr}}
 \DeclareOption{noqr}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,noqr}}
+% separator in head options: "separator" (default) or "noseparator"
 \DeclareOption{separator}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,separator}}
 \DeclareOption{noseparator}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,noseparator}}
+% data in head options: "details" (default) or "nodetails"
+\DeclareOption{details}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,details}}
+\DeclareOption{nodetails}{\edef\moderncvstyleheadoptions{\moderncvstyleheadoptions,nodetails}}
 
 \DeclareOption*{}% avoid choking on unknown options
-\ExecuteOptions{left,qr}
+\ExecuteOptions{left,qr,details,separator}
 \ProcessOptions*\relax% \ProcessOptions* processes the options in the order provided (i.e., with the later ones possibly overriding the former ones), while \ProcessOptions processes them in the order of the package
 
 %-------------------------------------------------------------------------------


### PR DESCRIPTION
Address #299:
- Correct the documented style option defaults, changing them from `nodetails` to `details` for the `classic`, `banking`, `oldstyle`, and `fancy` styles, to match the current implementation.
- Set the `details` option explicitly as default in the banking style.
- Add the missing `details` and `nodetails` options to the `contemporary` style, setting `details` and `separator` as explicit defaults.
- Update `CHANGELOG` with a summary of the changes and a reference to the issue they close.

Notes:
- When deciding what to change, I treated the headers as the source of truth, then the styles, and finally the documentation, to avoid breaking default behaviour.
- I will resolve the conflict in `CHANGELOG` between this PR and #298 if they are both merged. 