### PR TITLE
fix: Undefined control sequences with `MiKTeX` and `LuaLaTeX`/`XeLaTeX`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ version next
 - Set the details option explicitly as default in the banking style (#299)
 - Add the missing details and nodetails options to the contemporary style,
   setting details and separator as explicit defaults (#299)
+- Replace fontawesome shorthand commands with the \faIcon syntax (#296)
 
 
 version 2.6.0 (19 Jun 2026)

--- a/moderncvbodyvi.sty
+++ b/moderncvbodyvi.sty
@@ -78,7 +78,7 @@
 \settoheight{\baseletterheight}{\sectionstyle{o}}
 \setlength{\baseletterheight}{\baseletterheight-0.95ex}
 % The optional argument can be used to place a small icon near the section name.
-% E.g. `\section[\faBookmark]{Education}`
+% E.g. `\section[\faIcon{bookmark}]{Education}`
 \RenewDocumentCommand{\section}{sO{}m}{%
   \tl@resetchain%
   \par\addvspace{2.5ex}%

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -61,49 +61,51 @@
 %-------------------------------------------------------------------------------
 %                all symbols described in moderncv.cls
 %-------------------------------------------------------------------------------
-\renewcommand*{\labelitemi}          {\strut\textcolor{color1}{\tiny\faCircle[regular]}} % alternative: \faCircle (solid style)
+\renewcommand*{\labelitemi}          {\strut\textcolor{color1}{\tiny\faIcon[regular]{circle}}} % alternative: \faIcon{circle} (solid style)
 %\renewcommand*{\labelitemii}         {\strut\textcolor{color1}{\large\bfseries-}}            % no change from default in moderncv.cls
 %\renewcommand*{\labelitemiii}        {\strut\textcolor{color1}{\rmfamily\textperiodcentered}}% no change from default in moderncv.cls
 %\renewcommand*{\labelitemiv}         {\labelitemiii}                                         % no change from default in moderncv.cls
 
 
 %\renewcommand*{\addresssymbol}            {}
-\renewcommand*{\mobilephonesymbol}        {{\color{mobilephone}\small\faMobileScreen}~}            % alternative: \faMobile (solid style)
-\renewcommand*{\fixedphonesymbol}         {{\color{fixedphone}\small\faPhone}~}             % alternative: \faPhoneFlip (reversed)
-\renewcommand*{\faxphonesymbol}           {{\color{faxphone}\small\faFax}~}                % alternative: \faPrint
-\renewcommand*{\emailsymbol}              {{\color{email}\small\faEnvelope[regular]}~}  % alternative: \faInbox, \faEnvelope (solid style)
-\renewcommand*{\homepagesymbol}           {{\color{homepage}\small\faEarthAmericas}~}      % alternative: \faHouse, \faHouseChimney, \faGlobe, \faEarthEurope, \faEarthAfrica, \faEarthAsia, \faEarthOceania
-\renewcommand*{\linkedinsocialsymbol}     {{\color{linkedin}\small\faLinkedinIn}~}         % alternative: \faLinkedin
-\renewcommand*{\xingsocialsymbol}         {{\color{xing}\small\faXing}~}               % alternative: \faSquareXing
-\renewcommand*{\twittersocialsymbol}      {{\color{twitter}\small\faTwitter}~}            % alternative: \faSquareTwitter, \faXTwitter, \faSquareXTwitter
-\renewcommand*{\mastodonsocialsymbol}     {{\color{mastodon}\small\faMastodon}~}
-\renewcommand*{\githubsocialsymbol}       {{\color{github}\small\faGithub}~}             % alternative: \faSquareGithub, \faGithubAlt
-\renewcommand*{\gitlabsocialsymbol}       {{\color{gitlab}\small\faGitlab}~}
-\renewcommand*{\stackoverflowsocialsymbol}{{\color{stackoverflow}\small\faStackOverflow}~}
-\renewcommand*{\bitbucketsocialsymbol}    {{\color{bitbucket}\small\faBitbucket}~}
-\renewcommand*{\skypesocialsymbol}        {{\color{skype}\small\faSkype}~}
-\renewcommand*{\orcidsocialsymbol}        {{\color{orcid}\small\faOrcid}~}
-\renewcommand*{\researchgatesocialsymbol} {{\color{researchgate}\small\faResearchgate}~}
+\renewcommand*{\mobilephonesymbol}        {{\color{mobilephone}\small\faIcon{mobile-screen}}~}            % alternative: \faIcon{mobile} (solid style)
+\renewcommand*{\fixedphonesymbol}         {{\color{fixedphone}\small\faIcon{phone}}~}             % alternative: \faIcon{phone-flip} (reversed)
+\renewcommand*{\faxphonesymbol}           {{\color{faxphone}\small\faIcon{fax}}~}                % alternative: \faIcon{print}
+\renewcommand*{\emailsymbol}              {{\color{email}\small\faIcon[regular]{envelope}}~}  % alternative: \faIcon{inbox}, \faIcon{envelope} (solid style)
+\renewcommand*{\homepagesymbol}           {{\color{homepage}\small\faIcon{earth-americas}}~}      % alternative: \faIcon{house}, \faIcon{house-chimney}, \faIcon{globe}, \faIcon{earth-europe}, \faIcon{earth-africa}, \faIcon{earth-asia}, \faIcon{earth-oceania}
+\renewcommand*{\linkedinsocialsymbol}     {{\color{linkedin}\small\faIcon{linkedin-in}}~}         % alternative: \faIcon{linkedin}
+\renewcommand*{\xingsocialsymbol}         {{\color{xing}\small\faIcon{xing}}~}               % alternative: \faIcon{square-xing}
+\renewcommand*{\twittersocialsymbol}      {{\color{twitter}\small\faIcon{twitter}}~}            % alternative: \faIcon{square-twitter}, \faIcon{x-twitter}, \faIcon{square-x-twitter}
+\renewcommand*{\mastodonsocialsymbol}     {{\color{mastodon}\small\faIcon{mastodon}}~}
+\renewcommand*{\githubsocialsymbol}       {{\color{github}\small\faIcon{github}}~}             % alternative: \faIcon{square-github}, \faIcon{github-alt}
+\renewcommand*{\gitlabsocialsymbol}       {{\color{gitlab}\small\faIcon{gitlab}}~}
+\renewcommand*{\stackoverflowsocialsymbol}{{\color{stackoverflow}\small\faIcon{stack-overflow}}~}
+\renewcommand*{\bitbucketsocialsymbol}    {{\color{bitbucket}\small\faIcon{bitbucket}}~}
+\renewcommand*{\skypesocialsymbol}        {{\color{skype}\small\faIcon{skype}}~}
+\renewcommand*{\orcidsocialsymbol}        {{\color{orcid}\small\faIcon{orcid}}~}
+\renewcommand*{\researchgatesocialsymbol} {{\color{researchgate}\small\faIcon{researchgate}}~}
 %\renewcommand*{\researcheridsocialsymbol} {}
-\renewcommand*{\googlescholarsocialsymbol}{{\color{googlescholar}\small\faGoogleScholar}~}
-\renewcommand*{\telegramsocialsymbol}     {{\color{telegram}\small\faTelegram}~}
-\renewcommand*{\whatsappsocialsymbol}     {{\color{whatsapp}\small\faWhatsapp}~}
-\renewcommand*{\discordsocialsymbol}      {{\color{discord}\small\faDiscord}~}
-\renewcommand*{\twitchsocialsymbol}       {{\color{twitch}\small\faTwitch}~}
-\renewcommand*{\youtubesocialsymbol}      {{\color{youtube}\small\faYoutube}~}
-\renewcommand*{\tiktoksocialsymbol}       {{\color{tiktok}\small\faTiktok}~}
-\renewcommand*{\instagramsocialsymbol}    {{\color{instagram}\small\faInstagram}~}
-\renewcommand*{\soundcloudsocialsymbol}   {{\color{soundcloud}\small\faSoundcloud}~}
-\renewcommand*{\steamsocialsymbol}        {{\color{steam}\small\faSteam}~}
-\renewcommand*{\xboxsocialsymbol}         {{\color{xbox}\small\faXbox}~}
-\renewcommand*{\playstationsocialsymbol}  {{\color{playstation}\small\faPlaystation}~}
-\renewcommand*{\battlenetsocialsymbol}    {{\color{battlenet}\small\faBattleNet}~}
-\renewcommand*{\signalsocialsymbol}       {{\color{signal}\small\faSignalMessenger}~}
+\renewcommand*{\googlescholarsocialsymbol}{{\color{googlescholar}\small\faIcon{google-scholar}}~}
+\renewcommand*{\telegramsocialsymbol}     {{\color{telegram}\small\faIcon{telegram}}~}
+\renewcommand*{\whatsappsocialsymbol}     {{\color{whatsapp}\small\faIcon{whatsapp}}~}
+\renewcommand*{\discordsocialsymbol}      {{\color{discord}\small\faIcon{discord}}~}
+\renewcommand*{\twitchsocialsymbol}       {{\color{twitch}\small\faIcon{twitch}}~}
+\renewcommand*{\youtubesocialsymbol}      {{\color{youtube}\small\faIcon{youtube}}~}
+\renewcommand*{\tiktoksocialsymbol}       {{\color{tiktok}\small\faIcon{tiktok}}~}
+\renewcommand*{\instagramsocialsymbol}    {{\color{instagram}\small\faIcon{instagram}}~}
+\renewcommand*{\soundcloudsocialsymbol}   {{\color{soundcloud}\small\faIcon{soundcloud}}~}
+\renewcommand*{\steamsocialsymbol}        {{\color{steam}\small\faIcon{steam}}~}
+\renewcommand*{\xboxsocialsymbol}         {{\color{xbox}\small\faIcon{xbox}}~}
+\renewcommand*{\playstationsocialsymbol}  {{\color{playstation}\small\faIcon{playstation}}~}
+\renewcommand*{\battlenetsocialsymbol}    {{\color{battlenet}\small\faIcon{battle-net}}~}
+\renewcommand*{\signalsocialsymbol}       {{\color{signal}\small\faIcon{signal-messenger}}~}
 %\renewcommand*{\matrixsocialsymbol}       {}
-% \renewcommand*{\arxivsocialsymbol}        {{\color{arxiv}{\small\faarXiv}}~}
-% \renewcommand*{\inspiresocialsymbol}      {{\color{inspire}{\small\faInspire}}~}
-\renewcommand*{\bornsymbol}               {{\color{born}\raisebox{.5ex}{\tiny\faAsterisk}}~}           % alternative: \faBabyCarriage
-\renewcommand*{\mediumsocialsymbol}     {{\color{medium}\small\faMedium}~}
+% No arxiv icon in fontawesome6 (v6.7.2-3) or fontawesome7 (v7.1.0-1)
+% \renewcommand*{\arxivsocialsymbol}        {{\color{arxiv}{\small\faIcon{arxiv}}}~}
+% No inspire icon in fontawesome6 (v6.7.2-3) or fontawesome7 (v7.1.0-1)
+% \renewcommand*{\inspiresocialsymbol}      {{\color{inspire}{\small\faIcon{inspire}}}~}
+\renewcommand*{\bornsymbol}               {{\color{born}\raisebox{.5ex}{\tiny\faIcon{asterisk}}}~}           % alternative: \faIcon{baby-carriage}
+\renewcommand*{\mediumsocialsymbol}     {{\color{medium}\small\faIcon{medium}}~}
 
 
 \endinput

--- a/template.tex
+++ b/template.tex
@@ -133,7 +133,7 @@
 %-----       resume       ---------------------------------------------------------
 \makecvtitle
 
-\section{Education}  % for 'contemporary' style use optional argument for displaying an icon, e.g. \section[\faGraduationCap]{Education}
+\section{Education}  % for 'contemporary' style use optional argument for displaying an icon, e.g. \section[\faIcon{graduation-cap}]{Education}
 \cventry{year--year}{Degree}{Institution}{City}{\textit{Grade}}{Description}  % arguments 3 to 6 can be left empty
 \cventry{year--year}{Degree}{Institution}{City}{\textit{Grade}}{Description}
 


### PR DESCRIPTION
Address #296:
- Replace `fontawesome` shorthand commands with the `\faIcon` syntax.