### PR TITLE
Provide the "fixed" option to fontawesome

### DIFF
--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -16,7 +16,7 @@
 %                required packages
 %-------------------------------------------------------------------------------
 % Font Awesome font
-\RequirePackage{fontawesome7}
+\RequirePackage[fixed]{fontawesome7}
 \RequirePackage{xcolor}
 
 %-------------------------------------------------------------------------------


### PR DESCRIPTION
fontawesome offers the option "fixed", which renders all icons with the same width (by inserting symmetrical empty space, not by rescaling). In CV's the icons are usually used in some form of tabular display or aligned at some vertical edges to visually highlight single career stations or skills - but the icons are not used inside continuous text, like the motiviational letter of a CV. Using the "fixed" option provides a cleaner result for a tabular-oriented CV. To disable this again you can use `\PassOptionsToPackage{fixed=false}{fontawesome7}` just before `\documentclass{moderncv}`.