### PR TITLE
Fix Underfull \hbox in banking \subsection dotted rules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 version next
 - Upgrade to Fontawesome 7 (#270)
+- Fix "Underfull \hbox (badness 10000)" warning in banking \subsection dotted
+  rules by adding \hss glue as in \dotfill (#307)
 
 version 2.6.1 (24 Jun 2026)
 - Allow the customisation of the contemporary style (#297)

--- a/moderncvbodyiii.sty
+++ b/moderncvbodyiii.sty
@@ -139,13 +139,13 @@
 \newcommand*{\subsectionrule}{}
 \if@fullrules%
   \renewcommand*{\sectionrule}{\par\nobreak\vspace*{-.7\baselineskip}\leavevmode{\color{bodyrulecolor}\leaders\hbox{\rule{1pt}{0.4pt}}\hfill\kern0pt}}
-  \renewcommand*{\subsectionrule}{\par\nobreak\vspace*{-.7\baselineskip}\leavevmode{\color{bodyrulecolor}\xleaders\hbox to 0.35em{\scriptsize.}\hfill}}\fi% different subsectionrules will not be perfectly aligned, but remaining space at the end of the fill will be distributed evenly between leaders, so it will be barely visible}
+  \renewcommand*{\subsectionrule}{\par\nobreak\vspace*{-.7\baselineskip}\leavevmode{\color{bodyrulecolor}\xleaders\hbox to 0.35em{\hss\scriptsize.\hss}\hfill\kern0pt}}\fi% different subsectionrules will not be perfectly aligned, but remaining space at the end of the fill will be distributed evenly between leaders, so it will be barely visible}
 \if@shortrules%
   \renewcommand*{\sectionrule}{\leavevmode{\color{bodyrulecolor}\leaders\hbox{\rule{1pt}{0.4pt}}\hfill\kern0pt}}
-  \renewcommand*{\subsectionrule}{\leavevmode{\color{bodyrulecolor}\xleaders\hbox to 0.35em{\scriptsize.}\hfill}}\fi% different subsectionrules will not be perfectly aligned, but remaining space at the end of the fill will be distributed evenly between leaders, so it will be barely visible}}
+  \renewcommand*{\subsectionrule}{\leavevmode{\color{bodyrulecolor}\xleaders\hbox to 0.35em{\hss\scriptsize.\hss}\hfill\kern0pt}}\fi% different subsectionrules will not be perfectly aligned, but remaining space at the end of the fill will be distributed evenly between leaders, so it will be barely visible}}
 \if@mixedrules%
   \renewcommand*{\sectionrule}{\par\nobreak\vspace*{-.7\baselineskip}\leavevmode{\color{bodyrulecolor}\leaders\hbox{\rule{1pt}{0.4pt}}\hfill\kern0pt}}
-  \renewcommand*{\subsectionrule}{\leavevmode{\color{bodyrulecolor}\xleaders\hbox to 0.35em{\scriptsize.}\hfill}}\fi% different subsectionrules will not be perfectly aligned, but remaining space at the end of the fill will be distributed evenly between leaders, so it will be barely visible}}
+  \renewcommand*{\subsectionrule}{\leavevmode{\color{bodyrulecolor}\xleaders\hbox to 0.35em{\hss\scriptsize.\hss}\hfill\kern0pt}}\fi% different subsectionrules will not be perfectly aligned, but remaining space at the end of the fill will be distributed evenly between leaders, so it will be barely visible}}
 \if@norules%
   \renewcommand*{\sectionrule}{}
   \renewcommand*{\subsectionrule}{}\fi


### PR DESCRIPTION
Fixes #307.

## Summary
- Banking `\subsection` dotted leaders (`fullrules`, `shortrules`, `mixedrules` in `moderncvbodyiii.sty`) used `\hbox to 0.35em{\scriptsize.}` with no stretchable glue, which triggers `Underfull \hbox (badness 10000)` on every subsection.
- Give that slot `\hss` on both sides of the period, matching the LaTeX kernel's `\dotfill`:

```latex
\def\dotfill{%
  \leavevmode
  \cleaders \hb@xt@ .44em{\hss.\hss}\hfill
  \kern\z@}
```

- Keep banking's own choices: `\xleaders`, `0.35em`, `\scriptsize`, and `bodyrulecolor`. Add `\kern0pt` like `\dotfill` / `\sectionrule` so the `\hfill` is not discarded.

## Test plan
- [ ] Compile the MWE in #307 with `pdflatex` / `xelatex` and confirm the underfull box is gone.
- [ ] Visually check banking `\subsection` dots for `mixedrules` (default), `shortrules`, and `fullrules`.


Made with [Cursor](https://cursor.com)